### PR TITLE
PeerGroup and InitialSyncer Refactoring (#91)

### DIFF
--- a/WalletKit/WalletKit.xcodeproj/project.pbxproj
+++ b/WalletKit/WalletKit.xcodeproj/project.pbxproj
@@ -67,7 +67,6 @@
 		11B35DCEE58FE94B5E111622 /* InitialSyncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35660C3F6DE42BC99E350 /* InitialSyncer.swift */; };
 		11B35DD0EE93320729D517CE /* RequestMerkleBlocksPeerTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35AEAAB5F1F7246063AEB /* RequestMerkleBlocksPeerTask.swift */; };
 		11B35DD55E37F22AE1797501 /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35C67DB63EF992C380513 /* Transaction.swift */; };
-		11B35E6B68D14E5316690567 /* BlockSyncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35C07292793FCE3096D03 /* BlockSyncer.swift */; };
 		11B35EE64EEEE37EB90C5D14 /* PeerGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B359E44D75610DF2841327 /* PeerGroup.swift */; };
 		11B35EEF6EA44EF0378B60A3 /* BitcoinRegTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B35A0FD8DBCF14EC9AA8ED /* BitcoinRegTest.swift */; };
 		11B35F02260D5A21CF0EA3B8 /* Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3529A1731702724B0342D /* Factory.swift */; };
@@ -1331,7 +1330,6 @@
 				58AAA7537CABBC438DE391DF /* IBlockValidator.swift in Sources */,
 				2FA5D74EDAFB77BC86918E63 /* HostDiscovery.swift in Sources */,
 				58AAAB17C4576A1C730F65F6 /* P2MultiSigExtractor.swift in Sources */,
-				11B35E6B68D14E5316690567 /* BlockSyncer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WalletKit/WalletKit/Core/Logger.swift
+++ b/WalletKit/WalletKit/Core/Logger.swift
@@ -37,7 +37,7 @@ class Logger {
     func log(_ logTag: String, _ logString: String) {
         if allowedLogs.contains(logTag) {
             let timestamp = dateFormatter.string(from: Date())
-            print("\(timestamp): \(logString)\n")
+            print("\(timestamp): \(logString)")
         }
     }
 

--- a/WalletKit/WalletKit/Core/WalletKit.swift
+++ b/WalletKit/WalletKit/Core/WalletKit.swift
@@ -157,21 +157,21 @@ public class WalletKit {
     public func showRealmInfo() {
         let realm = realmFactory.realm
 
-        let blockCount = realm.objects(Block.self).count
-        let syncedBlockCount = realm.objects(Block.self).filter("synced = %@", true).count
-        let pubKeysCount = realm.objects(PublicKey.self).count
+        let blocks = realm.objects(Block.self).sorted(byKeyPath: "height")
+        let syncedBlocks = blocks.filter("synced = %@", true)
+        let pubKeys = realm.objects(PublicKey.self)
 
-        print("BLOCK COUNT: \(blockCount) --- \(syncedBlockCount) synced")
-        if let block = realm.objects(Block.self).first {
-            print("First Block: \(block.height) --- \(block.reversedHeaderHashHex)")
-        }
-        if let block = realm.objects(Block.self).last {
-            print("Last Block: \(block.height) --- \(block.reversedHeaderHashHex)")
-        }
-
-        print("PUBLIC KEYS COUNT: \(pubKeysCount)")
-        for pubKey in realm.objects(PublicKey.self) {
+        for pubKey in pubKeys {
             print("\(pubKey.index) --- \(pubKey.external) --- \(pubKey.address)")
+        }
+        print("PUBLIC KEYS COUNT: \(pubKeys.count)")
+
+        print("BLOCK COUNT: \(blocks.count) --- \(syncedBlocks.count) synced")
+        if let block = syncedBlocks.first {
+            print("First Synced Block: \(block.height) --- \(block.reversedHeaderHashHex)")
+        }
+        if let block = syncedBlocks.last {
+            print("Last Synced Block: \(block.height) --- \(block.reversedHeaderHashHex)")
         }
     }
 

--- a/WalletKit/WalletKit/Managers/ApiManager.swift
+++ b/WalletKit/WalletKit/Managers/ApiManager.swift
@@ -147,7 +147,7 @@ struct AddressResponse: ImmutableMappable {
 
 }
 
-struct BlockResponse: ImmutableMappable {
+struct BlockResponse: ImmutableMappable, Hashable {
     let hash: String
     let height: Int
 
@@ -159,6 +159,10 @@ struct BlockResponse: ImmutableMappable {
     init(map: Map) throws {
         hash = try map.value("hash")
         height = try map.value("height")
+    }
+
+    static func ==(lhs: BlockResponse, rhs: BlockResponse) -> Bool {
+        return lhs.height == rhs.height && lhs.hash == rhs.hash
     }
 
 }


### PR DESCRIPTION
- In PeerGroup: all modifications of "peers" are now performed in synced queue.
- Remove additional empty line in logger messages.
- Improve "Show Realm Info" message in log.
- Refactor InitialSyncer: do not create duplicate blocks, collect block responses first and then filter unique values from it.
- In PeerGroup: add additional log messages for dispatching and getting back block batches.
- Remove duplicate build record from project file (BlockSyncer.swift).

Closes #91 