### PR TITLE
"Address receive" and "transaction send" when not synced (#146)

### DIFF
--- a/HSBitcoinKit/HSBitcoinKit/Core/Protocols.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/Protocols.swift
@@ -81,7 +81,7 @@ protocol IPeerGroup: class {
     var transactionSyncer: ITransactionSyncer? { get set }
     func start()
     func stop()
-    func sendPendingTransactions()
+    func sendPendingTransactions() throws
 }
 
 protocol IPeerManager: class {
@@ -318,6 +318,7 @@ protocol INetwork: class {
     var checkpointBlock: Block { get }
     var coinType: UInt32 { get }
     var sigHash: SigHashType { get }
+    var syncableFromApi: Bool { get }
 
     // difficulty adjustment params
     var maxTargetBits: Int { get }                                      // Maximum difficulty.

--- a/HSBitcoinKit/HSBitcoinKit/Managers/InitialSyncer.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Managers/InitialSyncer.swift
@@ -92,6 +92,12 @@ class InitialSyncer {
 extension InitialSyncer: IInitialSyncer {
 
     func sync() throws {
+        try addressManager.fillGap()
+
+        if !network.syncableFromApi {
+            stateManager.apiSynced = true
+        }
+
         if !stateManager.apiSynced {
             let maxHeight = network.checkpointBlock.height
 

--- a/HSBitcoinKit/HSBitcoinKit/Network/BitcoinCashMainNet.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Network/BitcoinCashMainNet.swift
@@ -23,6 +23,7 @@ class BitcoinCashMainNet: INetwork {
     let port: UInt32 = 8333
     let coinType: UInt32 = 0
     let sigHash: SigHashType = .bitcoinCashAll
+    var syncableFromApi: Bool = true
 
     let dnsSeeds = [
         "seed.bitcoinabc.org",

--- a/HSBitcoinKit/HSBitcoinKit/Network/BitcoinCashTestNet.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Network/BitcoinCashTestNet.swift
@@ -16,6 +16,7 @@ class BitcoinCashTestNet: INetwork {
     let port: UInt32 = 18333
     let coinType: UInt32 = 1
     let sigHash: SigHashType = .bitcoinCashAll
+    var syncableFromApi: Bool = true
 
     let merkleBlockValidator: IMerkleBlockValidator
 

--- a/HSBitcoinKit/HSBitcoinKit/Network/BitcoinMainNet.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Network/BitcoinMainNet.swift
@@ -20,6 +20,7 @@ class BitcoinMainNet: INetwork {
     let port: UInt32 = 8333
     let coinType: UInt32 = 0
     let sigHash: SigHashType = .bitcoinAll
+    var syncableFromApi: Bool = true
 
     let dnsSeeds = [
         "seed.bitcoin.sipa.be",         // Pieter Wuille

--- a/HSBitcoinKit/HSBitcoinKit/Network/BitcoinRegTest.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Network/BitcoinRegTest.swift
@@ -18,6 +18,7 @@ class BitcoinRegTest: INetwork {
     let port: UInt32 = 18444
     let coinType: UInt32 = 1
     let sigHash: SigHashType = .bitcoinAll
+    var syncableFromApi: Bool = false
 
     let dnsSeeds = [
          "btc-regtest.horizontalsystems.xyz",

--- a/HSBitcoinKit/HSBitcoinKit/Network/BitcoinTestNet.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Network/BitcoinTestNet.swift
@@ -23,6 +23,7 @@ class BitcoinTestNet: INetwork {
     let port: UInt32 = 18333
     let coinType: UInt32 = 1
     let sigHash: SigHashType = .bitcoinAll
+    var syncableFromApi: Bool = true
 
     let dnsSeeds = [
         "testnet-seed.bitcoin.petertodd.org",    // Peter Todd

--- a/HSBitcoinKit/HSBitcoinKit/Transactions/TransactionCreator.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Transactions/TransactionCreator.swift
@@ -42,7 +42,7 @@ extension TransactionCreator: ITransactionCreator {
             transactionProcessor.process(transaction: transaction, realm: realm)
         }
 
-        peerGroup.sendPendingTransactions()
+        try peerGroup.sendPendingTransactions()
     }
 
 }


### PR DESCRIPTION
- InitialSyncer runs AddressManager#fillGap before API sync
- InitialSyncer shouldn't start API sync if network is not syncableFromApi
- PeerGroup#sendPendingTransactions throws exception if there's no peers connected or not all peers synced

Closes #146 