### PR TITLE
Multi-account (#207)

### DIFF
--- a/HSBitcoinKit.podspec
+++ b/HSBitcoinKit.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
   spec.swift_version = '4.1'
 
   spec.dependency 'HSCryptoKit'
-  spec.dependency 'HSHDWalletKit'
+  spec.dependency 'HSHDWalletKit', '~> 1.0.1'
   spec.dependency 'Alamofire'
   spec.dependency 'ObjectMapper'
   spec.dependency 'RxSwift'

--- a/HSBitcoinKit/HSBitcoinKit/Core/BitcoinKit.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/BitcoinKit.swift
@@ -137,7 +137,7 @@ public class BitcoinKit {
         peerGroup = PeerGroup(factory: factory, network: network, listener: kitStateProvider, reachabilityManager: reachabilityManager, peerHostManager: peerHostManager, bloomFilterManager: bloomFilterManager, logger: logger)
 
         addressManager = AddressManager(realmFactory: realmFactory, hdWallet: hdWallet, addressConverter: addressConverter)
-        initialSyncer = InitialSyncer(realmFactory: realmFactory, listener: kitStateProvider, hdWallet: hdWallet, stateManager: stateManager, api: initialSyncApi, addressManager: addressManager, addressSelector: addressSelector, factory: factory, peerGroup: peerGroup, network: network)
+        initialSyncer = InitialSyncer(realmFactory: realmFactory, listener: kitStateProvider, hdWallet: hdWallet, stateManager: stateManager, api: initialSyncApi, addressManager: addressManager, addressSelector: addressSelector, factory: factory, peerGroup: peerGroup, network: network, logger: logger)
 
         realmStorage = RealmStorage(realmFactory: realmFactory)
 

--- a/HSBitcoinKit/HSBitcoinKit/Core/DataProvider.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/DataProvider.swift
@@ -185,23 +185,22 @@ extension DataProvider: IDataProvider {
         let realm = realmFactory.realm
 
         let blocks = realm.objects(Block.self).sorted(byKeyPath: "height")
-        let syncedBlocks = blocks
         let pubKeys = realm.objects(PublicKey.self)
 
         for pubKey in pubKeys {
             let scriptType: ScriptType = (network is BitcoinCashMainNet || network is BitcoinCashTestNet) ? .p2pkh : .p2wpkh
             let bechAddress = (try? addressConverter.convert(keyHash: OpCode.scriptWPKH(pubKey.keyHash), type: scriptType).stringValue) ?? "none"
-            lines.append("\(pubKey.index) --- \(pubKey.external) --- hash: \(pubKey.keyHash.hex) --- p2wkph(SH) hash: \(pubKey.scriptHashForP2WPKH.hex)")
+            lines.append("\(pubKey.account) --- \(pubKey.index) --- \(pubKey.external) --- hash: \(pubKey.keyHash.hex) --- p2wkph(SH) hash: \(pubKey.scriptHashForP2WPKH.hex)")
             lines.append("legacy: \(addressConverter.convertToLegacy(keyHash: pubKey.keyHash, version: network.pubKeyHash, addressType: .pubKeyHash).stringValue) --- bech32: \(bechAddress) --- SH(WPKH): \(addressConverter.convertToLegacy(keyHash: pubKey.scriptHashForP2WPKH, version: network.scriptHash, addressType: .scriptHash).stringValue) \n")
         }
         lines.append("PUBLIC KEYS COUNT: \(pubKeys.count)")
 
-        lines.append("BLOCK COUNT: \(blocks.count) --- \(syncedBlocks.count) synced")
-        if let block = syncedBlocks.first {
-            lines.append("First Synced Block: \(block.height) --- \(block.reversedHeaderHashHex)")
+        lines.append("BLOCK COUNT: \(blocks.count)")
+        if let block = blocks.first {
+            lines.append("First Block: \(block.height) --- \(block.reversedHeaderHashHex)")
         }
-        if let block = syncedBlocks.last {
-            lines.append("Last Synced Block: \(block.height) --- \(block.reversedHeaderHashHex)")
+        if let block = blocks.last {
+            lines.append("Last Block: \(block.height) --- \(block.reversedHeaderHashHex)")
         }
 
         return lines.joined(separator: "\n")

--- a/HSBitcoinKit/HSBitcoinKit/Core/HDWallet.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/HDWallet.swift
@@ -2,12 +2,12 @@ import HSHDWalletKit
 
 extension HDWallet: IHDWallet {
 
-    func publicKey(index: Int, external: Bool) throws -> PublicKey {
-        return PublicKey(withIndex: index, external: external, hdPublicKeyData: try publicKey(index: index, chain: external ? .external : .internal).raw)
+    func publicKey(account: Int, index: Int, external: Bool) throws -> PublicKey {
+        return PublicKey(withAccount: account, index: index, external: external, hdPublicKeyData: try publicKey(account: account, index: index, chain: external ? .external : .internal).raw)
     }
 
-    func privateKeyData(index: Int, external: Bool) throws -> Data {
-        return try privateKey(index: index, chain: external ? .external : .internal).raw
+    func privateKeyData(account: Int, index: Int, external: Bool) throws -> Data {
+        return try privateKey(account: account, index: index, chain: external ? .external : .internal).raw
     }
 
 }

--- a/HSBitcoinKit/HSBitcoinKit/Core/Protocols.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/Protocols.swift
@@ -30,8 +30,8 @@ protocol IRealmFactory {
 
 protocol IHDWallet {
     var gapLimit: Int { get }
-    func publicKey(index: Int, external: Bool) throws -> PublicKey
-    func privateKeyData(index: Int, external: Bool) throws -> Data
+    func publicKey(account: Int, index: Int, external: Bool) throws -> PublicKey
+    func privateKeyData(account: Int, index: Int, external: Bool) throws -> Data
 }
 
 protocol IApiConfigProvider {

--- a/HSBitcoinKit/HSBitcoinKit/Managers/AddressManager.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Managers/AddressManager.swift
@@ -18,17 +18,18 @@ class AddressManager {
         self.hdWallet = hdWallet
     }
 
-    private func fillGap(external: Bool) throws {
+    private func fillGap(account: Int, external: Bool) throws {
         let realm = realmFactory.realm
-        let publicKeys = realm.objects(PublicKey.self).filter("external = %@", external)
+        let publicKeys = realm.objects(PublicKey.self).filter("account = %@ AND external = %@", account, external)
         let gapKeysCount = self.gapKeysCount(publicKeyResults: publicKeys)
         var keys = [PublicKey]()
+
         if gapKeysCount < hdWallet.gapLimit {
             let allKeys = publicKeys.sorted(byKeyPath: "index")
             let lastIndex = allKeys.last?.index ?? -1
 
             for i in 1..<(hdWallet.gapLimit - gapKeysCount + 1) {
-                let publicKey = try hdWallet.publicKey(index: lastIndex + i, external: external)
+                let publicKey = try hdWallet.publicKey(account: account, index: lastIndex + i, external: external)
                 keys.append(publicKey)
             }
         }
@@ -37,21 +38,20 @@ class AddressManager {
     }
 
     private func gapKeysCount(publicKeyResults publicKeys: Results<PublicKey>) -> Int {
-        var gapKeysCount = 0
-
         if let lastUsedKey = publicKeys.filter("outputs.@count > 0").sorted(byKeyPath: "index").last {
-            gapKeysCount = publicKeys.filter("index > %@", lastUsedKey.index).count
+            return publicKeys.filter("index > %@", lastUsedKey.index).count
         } else {
-            gapKeysCount = publicKeys.count
+            return publicKeys.count
         }
-
-        return gapKeysCount
     }
 
     private func publicKey(external: Bool) throws -> PublicKey {
         let realm = realmFactory.realm
 
-        guard let unusedKey = realm.objects(PublicKey.self).filter("external = %@ AND outputs.@count = 0", external).sorted(byKeyPath: "index").first else {
+        guard let unusedKey = realm.objects(PublicKey.self)
+                .filter("external = %@ AND outputs.@count = 0", external)
+                .sorted(by: [SortDescriptor(keyPath: "account"), SortDescriptor(keyPath: "index")])
+                .first else {
             throw AddressManagerError.noUnusedPublicKey
         }
 
@@ -70,8 +70,18 @@ extension AddressManager: IAddressManager {
     }
 
     func fillGap() throws {
-        try fillGap(external: true)
-        try fillGap(external: false)
+        let requiredAccountsCount: Int!
+
+        if let lastUsedAccount = realmFactory.realm.objects(PublicKey.self).filter("outputs.@count > 0").sorted(byKeyPath: "account").last?.account {
+            requiredAccountsCount = lastUsedAccount + 1 + 1 // One because account starts from 0, One because we must have n+1 accounts
+        } else {
+            requiredAccountsCount = 1
+        }
+
+        for i in 0..<requiredAccountsCount {
+            try fillGap(account: i, external: true)
+            try fillGap(account: i, external: false)
+        }
     }
 
     func addKeys(keys: [PublicKey]) throws {
@@ -86,12 +96,23 @@ extension AddressManager: IAddressManager {
     }
 
     func gapShifts() -> Bool {
-        let realm = realmFactory.realm
+        guard let lastAccount = realmFactory.realm.objects(PublicKey.self).sorted(byKeyPath: "account").last?.account else {
+            return false
+        }
 
-        let externalPublicKeys = realm.objects(PublicKey.self).filter("external = %@", true)
-        let internalPublicKeys = realm.objects(PublicKey.self).filter("external = %@", false)
+        let publicKeys = realmFactory.realm.objects(PublicKey.self)
 
-        return gapKeysCount(publicKeyResults: externalPublicKeys) < hdWallet.gapLimit || gapKeysCount(publicKeyResults: internalPublicKeys) < hdWallet.gapLimit
+        for i in 0..<(lastAccount + 1) {
+            if gapKeysCount(publicKeyResults: publicKeys.filter("account = %@ AND external = %@", i, true)) < hdWallet.gapLimit {
+                return true
+            }
+
+            if gapKeysCount(publicKeyResults: publicKeys.filter("account = %@ AND external = %@", i, false)) < hdWallet.gapLimit {
+                return true
+            }
+        }
+
+        return false
     }
 
 }

--- a/HSBitcoinKit/HSBitcoinKit/Models/PublicKey.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Models/PublicKey.swift
@@ -11,6 +11,7 @@ class PublicKey: Object {
 
     let outputs = LinkingObjects(fromType: TransactionOutput.self, property: "publicKey")
 
+    @objc dynamic var account = 0
     @objc dynamic var index = 0
     @objc dynamic var external = true
     @objc dynamic var raw = Data()
@@ -22,8 +23,9 @@ class PublicKey: Object {
         return "keyHashHex"
     }
 
-    convenience init(withIndex index: Int, external: Bool, hdPublicKeyData data: Data) {
+    convenience init(withAccount account: Int, index: Int, external: Bool, hdPublicKeyData data: Data) {
         self.init()
+        self.account = account
         self.index = index
         self.external = external
         raw = data

--- a/HSBitcoinKit/HSBitcoinKit/Network/BitcoinTestNet.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Network/BitcoinTestNet.swift
@@ -47,13 +47,13 @@ class BitcoinTestNet: INetwork {
     let checkpointBlock = Block(
             withHeader: BlockHeader(
                     version: 536870912,
-                    previousBlockHeaderReversedHex: "00000000000001ade79216032b49854c966a1061fd3f8c6c56a0d38d0024629e",
-                    merkleRootReversedHex: "e5221c3269c569c9eeb58cfcbca48041b08902567917860ac2216ffc051be8ca",
-                    timestamp: 1539885052,
-                    bits: 436304224,
-                    nonce: 2919305209
+                    previousBlockHeaderReversedHex: "000000000010408eceeb1afbea4adcf41587f72d1ccf8b5900d058196dc3d283",
+                    merkleRootReversedHex: "56c0dfb52b41ae9b8ca93eda6c3e5bffd23543f79ab8be701e9ec19100d65274",
+                    timestamp: 1544611051,
+                    bits: 436294249,
+                    nonce: 1227763320
             ),
-            height: 1439424)
+            height: 1447502)
 
     required init(validatorFactory: IBlockValidatorFactory) {
         headerValidator = validatorFactory.validator(for: .header)

--- a/HSBitcoinKit/HSBitcoinKit/Transactions/Builder/InputSigner.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Transactions/Builder/InputSigner.swift
@@ -33,7 +33,7 @@ extension InputSigner: IInputSigner {
 
         let publicKey = pubKey.raw
 
-        guard let privateKeyData = try? hdWallet.privateKeyData(index: pubKey.index, external: pubKey.external) else {
+        guard let privateKeyData = try? hdWallet.privateKeyData(account: pubKey.account, index: pubKey.index, external: pubKey.external) else {
             throw SignError.noPrivateKey
         }
         let witness = prevOutput.scriptType == .p2wpkh || prevOutput.scriptType == .p2wpkhSh

--- a/HSBitcoinKit/HSBitcoinKitTests/Managers/BloomFilterManagerTests.swift
+++ b/HSBitcoinKit/HSBitcoinKitTests/Managers/BloomFilterManagerTests.swift
@@ -195,8 +195,8 @@ class BloomFilterManagerTests: XCTestCase {
 
 
     private func getPublicKey(withIndex index: Int, chain: HDWallet.Chain) -> PublicKey {
-        let hdPrivKeyData = try! hdWallet.privateKeyData(index: index, external: chain == .external)
-        return PublicKey(withIndex: index, external: chain == .external, hdPublicKeyData: hdPrivKeyData)
+        let hdPrivKeyData = try! hdWallet.privateKeyData(account: 0, index: index, external: chain == .external)
+        return PublicKey(withAccount: 0, index: index, external: chain == .external, hdPublicKeyData: hdPrivKeyData)
     }
 
     private func byteArrayLittleEndian(int: Int) -> [UInt8] {

--- a/HSBitcoinKit/HSBitcoinKitTests/Transactions/Builder/InputSignerTests.swift
+++ b/HSBitcoinKit/HSBitcoinKitTests/Transactions/Builder/InputSignerTests.swift
@@ -44,7 +44,7 @@ class InputSignerTests: XCTestCase {
         mockNetwork = MockINetwork()
 
         stub(mockHDWallet) { mock in
-            when(mock.privateKeyData(index: any(), external: any())).thenReturn(privateKey)
+            when(mock.privateKeyData(account: any(), index: any(), external: any())).thenReturn(privateKey)
         }
         stub(mockNetwork) { mock in
             when(mock.sigHash.get).thenReturn(SigHashType.bitcoinAll)
@@ -174,7 +174,7 @@ class InputSignerTests: XCTestCase {
 
     func testNoPrivateKey() {
         stub(mockHDWallet) { mock in
-            when(mock.privateKeyData(index: any(), external: any())).thenThrow(InputSigner.SignError.noPreviousOutputAddress)
+            when(mock.privateKeyData(account: any(), index: any(), external: any())).thenThrow(InputSigner.SignError.noPreviousOutputAddress)
         }
 
         var caught = false

--- a/HSBitcoinKitDemo/HSBitcoinKitDemo/Manager.swift
+++ b/HSBitcoinKitDemo/HSBitcoinKitDemo/Manager.swift
@@ -40,7 +40,7 @@ class Manager {
     }
 
     private func initWalletKit(words: [String]) {
-        bitcoinKit = BitcoinKit(withWords: words, coin: coin)
+        bitcoinKit = BitcoinKit(withWords: words, coin: coin, confirmationsThreshold: 1)
         bitcoinKit.delegate = self
     }
 

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ project 'HSBitcoinKit/HSBitcoinKit'
 
 def internal_pods
   pod 'HSCryptoKit'
-  pod 'HSHDWalletKit'
+  pod 'HSHDWalletKit', '~> 1.0.1'
 end
 
 def kit_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - SipHash (~> 1.2)
   - Cuckoo (0.11.3)
   - HSCryptoKit (1.0.0)
-  - HSHDWalletKit (1.0.0):
+  - HSHDWalletKit (1.0.1):
     - HSCryptoKit
   - ObjectMapper (3.3.0)
   - Realm (3.11.0):
@@ -23,7 +23,7 @@ DEPENDENCIES:
   - BigInt
   - Cuckoo
   - HSCryptoKit
-  - HSHDWalletKit
+  - HSHDWalletKit (~> 1.0.1)
   - ObjectMapper
   - RealmSwift
   - RxRealm
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   BigInt: 76b5dfdfa3e2e478d4ffdf161aeede5502e2742f
   Cuckoo: 97522dd7ac6f18adba6022bdc74aa69e82ca691a
   HSCryptoKit: 03c84aca081a6bcc999021d0acbf0cf7cf785d34
-  HSHDWalletKit: ff8ca1e074835447a7c1a13e56917fa72cc2fcd0
+  HSHDWalletKit: b3207ba91c73e32905964b36a0faf5c1da287cdd
   ObjectMapper: b612bf8c8e99c4dc0bb6013a51f7c27966ed5da9
   Realm: 92f09a102692b96a9a10e9617f214f15c5ab85fc
   RealmSwift: 5f0481cd658bb751c509314b964a35eaa264d2cf
@@ -56,6 +56,6 @@ SPEC CHECKSUMS:
   RxSwift: fe0fd770a43acdb7d0a53da411c9b892e69bb6e4
   SipHash: fad90a4683e420c52ef28063063dbbce248ea6d4
 
-PODFILE CHECKSUM: 1a2effba4d0a10b310a52a7a7d8e5338a2dcc811
+PODFILE CHECKSUM: 80f4ef001bd51248b6aad22c6bea2e8e94911d81
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
- InitialSyncer downloads blockHashes until it has one account without any used keys
- AddressManager#fillGap ensures that at least one account has no used keys
- AddressManager#gapShifts checks shifts in all existing accounts
- AddressManager#changeAddress returns unused internal keys sorted by account then by index

closes #207 