### PR TITLE
Use listener instead realm observer in data provider

### DIFF
--- a/HSBitcoinKit/HSBitcoinKit/Core/BitcoinKit.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/BitcoinKit.swift
@@ -70,7 +70,7 @@ public class BitcoinKit {
     private let blockSyncer: IBlockSyncer
 
     private let kitStateProvider: IKitStateProvider & ISyncStateListener
-    private var dataProvider: IDataProvider
+    private var dataProvider: IDataProvider & IBlockchainDataListener
 
     public init(withWords words: [String], coin: Coin, walletId: String, newWallet: Bool = false, confirmationsThreshold: Int = 6, minLogLevel: Logger.Level = .verbose) {
         let realmFileName = "\(walletId)-\(coin.rawValue).realm"
@@ -167,15 +167,18 @@ public class BitcoinKit {
         transactionSyncer = TransactionSyncer(realmFactory: realmFactory, processor: transactionProcessor, addressManager: addressManager, bloomFilterManager: bloomFilterManager)
         transactionBuilder = TransactionBuilder(unspentOutputSelector: unspentOutputSelector, unspentOutputProvider: unspentOutputProvider, addressManager: addressManager, addressConverter: addressConverter, inputSigner: inputSigner, scriptBuilder: scriptBuilder, factory: factory)
         transactionCreator = TransactionCreator(realmFactory: realmFactory, transactionBuilder: transactionBuilder, transactionProcessor: transactionProcessor, peerGroup: peerGroup)
-        blockchain = Blockchain(network: network, factory: factory)
 
         dataProvider = DataProvider(realmFactory: realmFactory, addressManager: addressManager, addressConverter: addressConverter, paymentAddressParser: paymentAddressParser, unspentOutputProvider: unspentOutputProvider, feeRateManager: feeRateManager, transactionCreator: transactionCreator, transactionBuilder: transactionBuilder, network: network)
+
+        blockchain = Blockchain(network: network, factory: factory, listener: dataProvider)
         blockSyncer = BlockSyncer(realmFactory: realmFactory, network: network, listener: kitStateProvider, transactionProcessor: transactionProcessor, blockchain: blockchain, addressManager: addressManager, bloomFilterManager: bloomFilterManager, logger: logger)
 
         peerGroup.blockSyncer = blockSyncer
         peerGroup.transactionSyncer = transactionSyncer
 
         kitStateProvider.delegate = self
+        transactionProcessor.listener = dataProvider
+
         dataProvider.delegate = self
     }
 
@@ -242,8 +245,12 @@ extension BitcoinKit {
 
 extension BitcoinKit: IDataProviderDelegate {
 
-    func transactionsUpdated(inserted: [TransactionInfo], updated: [TransactionInfo], deleted: [Int]) {
-        delegate?.transactionsUpdated(bitcoinKit: self, inserted: inserted, updated: updated, deleted: deleted)
+    func transactionsUpdated(inserted: [TransactionInfo], updated: [TransactionInfo]) {
+        delegate?.transactionsUpdated(bitcoinKit: self, inserted: inserted, updated: updated)
+    }
+
+    func transactionsDeleted(hashes: [String]) {
+        delegate?.transactionsDeleted(hashes: hashes)
     }
 
     func balanceUpdated(balance: Int) {
@@ -263,7 +270,8 @@ extension BitcoinKit: IKitStateProviderDelegate {
 }
 
 public protocol BitcoinKitDelegate: class {
-    func transactionsUpdated(bitcoinKit: BitcoinKit, inserted: [TransactionInfo], updated: [TransactionInfo], deleted: [Int])
+    func transactionsUpdated(bitcoinKit: BitcoinKit, inserted: [TransactionInfo], updated: [TransactionInfo])
+    func transactionsDeleted(hashes: [String])
     func balanceUpdated(bitcoinKit: BitcoinKit, balance: Int)
     func lastBlockInfoUpdated(bitcoinKit: BitcoinKit, lastBlockInfo: BlockInfo)
     func kitStateUpdated(state: BitcoinKit.KitState)

--- a/HSBitcoinKit/HSBitcoinKit/Core/BitcoinKit.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/BitcoinKit.swift
@@ -8,6 +8,7 @@ import RxSwift
 public class BitcoinKit {
 
     public weak var delegate: BitcoinKitDelegate?
+    public var delegateQueue = DispatchQueue(label: "bitcoin_delegate_queue")
 
     private var unspentOutputsNotificationToken: NotificationToken?
     private var transactionsNotificationToken: NotificationToken?
@@ -246,26 +247,42 @@ extension BitcoinKit {
 extension BitcoinKit: IDataProviderDelegate {
 
     func transactionsUpdated(inserted: [TransactionInfo], updated: [TransactionInfo]) {
-        delegate?.transactionsUpdated(bitcoinKit: self, inserted: inserted, updated: updated)
+        delegateQueue.async { [weak self] in
+            if let kit = self {
+                kit.delegate?.transactionsUpdated(bitcoinKit: kit, inserted: inserted, updated: updated)
+            }
+        }
     }
 
     func transactionsDeleted(hashes: [String]) {
-        delegate?.transactionsDeleted(hashes: hashes)
+        delegateQueue.async { [weak self] in
+            self?.delegate?.transactionsDeleted(hashes: hashes)
+        }
     }
 
     func balanceUpdated(balance: Int) {
-        delegate?.balanceUpdated(bitcoinKit: self, balance: balance)
+        delegateQueue.async { [weak self] in
+            if let kit = self {
+                kit.delegate?.balanceUpdated(bitcoinKit: kit, balance: balance)
+            }
+        }
     }
 
     func lastBlockInfoUpdated(lastBlockInfo: BlockInfo) {
-        delegate?.lastBlockInfoUpdated(bitcoinKit: self, lastBlockInfo: lastBlockInfo)
+        delegateQueue.async { [weak self] in
+            if let kit = self {
+                kit.delegate?.lastBlockInfoUpdated(bitcoinKit: kit, lastBlockInfo: lastBlockInfo)
+            }
+        }
     }
 
 }
 
 extension BitcoinKit: IKitStateProviderDelegate {
     func handleKitStateUpdate(state: KitState) {
-        delegate?.kitStateUpdated(state: state)
+        delegateQueue.async { [weak self] in
+            self?.delegate?.kitStateUpdated(state: state)
+        }
     }
 }
 

--- a/HSBitcoinKit/HSBitcoinKit/Core/DataProvider.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/DataProvider.swift
@@ -38,10 +38,10 @@ class DataProvider {
         self.balance = unspentOutputProvider.balance
         self.lastBlockInfo = realmFactory.realm.objects(Block.self).sorted(byKeyPath: "height").last.map { blockInfo(fromBlock: $0) }
 
-        balanceUpdateSubject.debounce(debounceTime, scheduler: MainScheduler.instance).subscribeAsync(disposeBag: disposeBag, onNext: {
+        balanceUpdateSubject.debounce(debounceTime, scheduler: ConcurrentDispatchQueueScheduler(qos: .background)).subscribe(onNext: {
             self.balance = unspentOutputProvider.balance
             self.delegate?.balanceUpdated(balance: self.balance)
-        })
+        }).disposed(by: disposeBag)
     }
 
     private func transactionInfo(fromTransaction transaction: Transaction) -> TransactionInfo {

--- a/HSBitcoinKit/HSBitcoinKit/Core/DataProvider.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/DataProvider.swift
@@ -20,9 +20,6 @@ class DataProvider {
 
     private let balanceUpdateSubject = PublishSubject<Void>()
 
-    private var transactionsNotificationToken: NotificationToken?
-    private var blocksNotificationToken: NotificationToken?
-
     public var balance: Int = 0
     public var lastBlockInfo: BlockInfo? = nil
 
@@ -39,54 +36,12 @@ class DataProvider {
         self.transactionBuilder = transactionBuilder
         self.network = network
         self.balance = unspentOutputProvider.balance
-        self.lastBlockInfo = blockRealmResults.last.map { blockInfo(fromBlock: $0) }
+        self.lastBlockInfo = realmFactory.realm.objects(Block.self).sorted(byKeyPath: "height").last.map { blockInfo(fromBlock: $0) }
 
         balanceUpdateSubject.debounce(debounceTime, scheduler: MainScheduler.instance).subscribeAsync(disposeBag: disposeBag, onNext: {
             self.balance = unspentOutputProvider.balance
             self.delegate?.balanceUpdated(balance: self.balance)
         })
-
-        transactionsNotificationToken = transactionRealmResults.observe { [weak self] changeset in
-            self?.handleTransactions(changeset: changeset)
-        }
-
-        blocksNotificationToken = blockRealmResults.observe { [weak self] changeset in
-            self?.handleBlocks(changeset: changeset)
-        }
-    }
-
-    deinit {
-        transactionsNotificationToken?.invalidate()
-        blocksNotificationToken?.invalidate()
-    }
-
-    private func handleTransactions(changeset: RealmCollectionChange<Results<Transaction>>) {
-        if case let .update(collection, deletions, insertions, modifications) = changeset {
-            delegate?.transactionsUpdated(
-                    inserted: insertions.map { collection[$0] }.map { transactionInfo(fromTransaction: $0) },
-                    updated: modifications.map { collection[$0] }.map { transactionInfo(fromTransaction: $0) },
-                    deleted: deletions
-            )
-            balanceUpdateSubject.onNext(())
-        }
-    }
-
-    private func handleBlocks(changeset: RealmCollectionChange<Results<Block>>) {
-        if case let .update(collection, deletions, insertions, _) = changeset, let block = collection.last, (!deletions.isEmpty || !insertions.isEmpty) {
-            let blockInfo = self.blockInfo(fromBlock: block)
-            lastBlockInfo = blockInfo
-
-            delegate?.lastBlockInfoUpdated(lastBlockInfo: blockInfo)
-            balanceUpdateSubject.onNext(())
-        }
-    }
-
-    private var transactionRealmResults: Results<Transaction> {
-        return realmFactory.realm.objects(Transaction.self).filter("isMine = %@", true).sorted(byKeyPath: "block.height", ascending: false)
-    }
-
-    private var blockRealmResults: Results<Block> {
-        return realmFactory.realm.objects(Block.self).sorted(byKeyPath: "height")
     }
 
     private func transactionInfo(fromTransaction transaction: Transaction) -> TransactionInfo {
@@ -140,6 +95,33 @@ class DataProvider {
                 height: block.height,
                 timestamp: block.header?.timestamp
         )
+    }
+
+}
+
+extension DataProvider: IBlockchainDataListener {
+
+    func onUpdate(updated: [Transaction], inserted: [Transaction]) {
+        delegate?.transactionsUpdated(inserted: inserted.map { transactionInfo(fromTransaction: $0) },
+                                      updated: updated.map { transactionInfo(fromTransaction: $0) })
+
+        balanceUpdateSubject.onNext(())
+    }
+
+    func onDelete(transactionHashes: [String]) {
+        delegate?.transactionsDeleted(hashes: transactionHashes)
+
+        balanceUpdateSubject.onNext(())
+    }
+
+    func onInsert(block: Block) {
+        if block.height > (lastBlockInfo?.height ?? 0) {
+            let lastBlockInfo = blockInfo(fromBlock: block)
+            self.lastBlockInfo = lastBlockInfo
+            delegate?.lastBlockInfoUpdated(lastBlockInfo: lastBlockInfo)
+
+            balanceUpdateSubject.onNext(())
+        }
     }
 
 }

--- a/HSBitcoinKit/HSBitcoinKit/Core/Protocols.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/Protocols.swift
@@ -257,9 +257,11 @@ protocol IScriptExtractor: class {
     func extract(from data: Data, converter: IScriptConverter) throws -> Data?
 }
 
-protocol ITransactionProcessor {
+protocol ITransactionProcessor: class {
+    var listener: IBlockchainDataListener? { get set }
+
     func process(transactions: [Transaction], inBlock block: Block?, skipCheckBloomFilter: Bool, realm: Realm) throws
-    func process(transaction: Transaction, realm: Realm)
+    func processOutgoing(transaction: Transaction, realm: Realm) throws
 }
 
 protocol ITransactionExtractor {
@@ -295,11 +297,20 @@ protocol ITransactionBuilder {
 }
 
 protocol IBlockchain {
+    var listener: IBlockchainDataListener? { get set }
+
     func connect(merkleBlock: MerkleBlock, realm: Realm) throws -> Block
     func forceAdd(merkleBlock: MerkleBlock, height: Int, realm: Realm) -> Block
     func handleFork(realm: Realm)
     func deleteBlocks(blocks: Results<Block>, realm: Realm)
 }
+
+protocol IBlockchainDataListener: class {
+    func onUpdate(updated: [Transaction], inserted: [Transaction])
+    func onDelete(transactionHashes: [String])
+    func onInsert(block: Block)
+}
+
 
 protocol IInputSigner {
     func sigScriptData(transaction: Transaction, index: Int) throws -> [Data]
@@ -365,7 +376,8 @@ protocol IDataProvider {
 }
 
 protocol IDataProviderDelegate: class {
-    func transactionsUpdated(inserted: [TransactionInfo], updated: [TransactionInfo], deleted: [Int])
+    func transactionsUpdated(inserted: [TransactionInfo], updated: [TransactionInfo])
+    func transactionsDeleted(hashes: [String])
     func balanceUpdated(balance: Int)
     func lastBlockInfoUpdated(lastBlockInfo: BlockInfo)
 }

--- a/HSBitcoinKit/HSBitcoinKit/Managers/FeeRateManager.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Managers/FeeRateManager.swift
@@ -17,7 +17,7 @@ class FeeRateManager {
 
         self.timer.delegate = self
 
-        reachabilityManager.subject
+        reachabilityManager.subject.observeOn(ConcurrentDispatchQueueScheduler(qos: .background))
                 .subscribe(onNext: { [weak self] connected in
                     if connected {
                         self?.updateFeeRate()

--- a/HSBitcoinKit/HSBitcoinKit/Managers/FeeRateSyncer.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Managers/FeeRateSyncer.swift
@@ -24,9 +24,8 @@ extension FeeRateSyncer: IFeeRateSyncer {
         var observable = networkManager.getFeeRate()
 
         if async {
-            observable = observable.subscribeOn(ConcurrentDispatchQueueScheduler(qos: .background)).observeOn(MainScheduler.instance)
+            observable = observable.subscribeOn(ConcurrentDispatchQueueScheduler(qos: .background))
         }
-
         observable
                 .subscribe(onNext: { [weak self] feeRate in
                     self?.timer.schedule()

--- a/HSBitcoinKit/HSBitcoinKit/Transactions/TransactionCreator.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Transactions/TransactionCreator.swift
@@ -30,11 +30,7 @@ extension TransactionCreator: ITransactionCreator {
             throw CreationError.transactionAlreadyExists
         }
 
-        try realm.write {
-            realm.add(transaction)
-            transactionProcessor.process(transaction: transaction, realm: realm)
-        }
-
+        try transactionProcessor.processOutgoing(transaction: transaction, realm: realm)
         try peerGroup.sendPendingTransactions()
     }
 

--- a/HSBitcoinKit/HSBitcoinKitTests/Blocks/BlockSyncerTests.swift
+++ b/HSBitcoinKit/HSBitcoinKitTests/Blocks/BlockSyncerTests.swift
@@ -51,7 +51,7 @@ class BlockSyncerTests: XCTestCase {
         }
 
         stub(mockTransactionProcessor) { mock in
-            when(mock.process(transaction: any(), realm: any())).thenDoNothing()
+            when(mock.processOutgoing(transaction: any(), realm: any())).thenDoNothing()
         }
         stub(mockBlockchain) { mock in
             when(mock.deleteBlocks(blocks: any(), realm: any())).thenDoNothing()

--- a/HSBitcoinKit/HSBitcoinKitTests/Transactions/TransactionProcessorTests.swift
+++ b/HSBitcoinKit/HSBitcoinKitTests/Transactions/TransactionProcessorTests.swift
@@ -9,6 +9,7 @@ class TransactionProcessorTests: XCTestCase {
     private var mockInputExtractor: MockITransactionExtractor!
     private var mockLinker: MockITransactionLinker!
     private var mockAddressManager: MockIAddressManager!
+    private var mockBlockchainDataListener: MockIBlockchainDataListener!
 
     private var generatedDate: Date!
     private var dateGenerator: (() -> Date)!
@@ -38,6 +39,7 @@ class TransactionProcessorTests: XCTestCase {
         mockInputExtractor = MockITransactionExtractor()
         mockLinker = MockITransactionLinker()
         mockAddressManager = MockIAddressManager()
+        mockBlockchainDataListener = MockIBlockchainDataListener()
 
         stub(mockLinker) { mock in
             when(mock.handle(transaction: any(), realm: any())).thenDoNothing()
@@ -54,8 +56,13 @@ class TransactionProcessorTests: XCTestCase {
         stub(mockAddressManager) { mock in
             when(mock.gapShifts()).thenReturn(false)
         }
+        stub(mockBlockchainDataListener) { mock in
+            when(mock.onUpdate(updated: any(), inserted: any())).thenDoNothing()
+            when(mock.onDelete(transactionHashes: any())).thenDoNothing()
+            when(mock.onInsert(block: any())).thenDoNothing()
+        }
 
-        transactionProcessor = TransactionProcessor(outputExtractor: mockOutputExtractor, inputExtractor: mockInputExtractor, linker: mockLinker, outputAddressExtractor: mockOutputAddressExtractor, addressManager: mockAddressManager, dateGenerator: dateGenerator)
+        transactionProcessor = TransactionProcessor(outputExtractor: mockOutputExtractor, inputExtractor: mockInputExtractor, linker: mockLinker, outputAddressExtractor: mockOutputAddressExtractor, addressManager: mockAddressManager, listener: mockBlockchainDataListener, dateGenerator: dateGenerator)
     }
 
     override func tearDown() {
@@ -63,6 +70,7 @@ class TransactionProcessorTests: XCTestCase {
         mockInputExtractor = nil
         mockLinker = nil
         transactionProcessor = nil
+        mockBlockchainDataListener = nil
 
         generatedDate = nil
         dateGenerator = nil
@@ -75,14 +83,11 @@ class TransactionProcessorTests: XCTestCase {
     func testProcessSingleTransaction() {
         let transaction = TestData.p2pkhTransaction
 
-        try! realm.write {
-            realm.add(transaction)
-        }
-
-        transactionProcessor.process(transaction: transaction, realm: realm)
+        try! transactionProcessor.processOutgoing(transaction: transaction, realm: realm)
 
         verify(mockOutputExtractor).extract(transaction: equal(to: transaction))
         verify(mockLinker).handle(transaction: equal(to: transaction), realm: equal(to: realm))
+        verify(mockBlockchainDataListener).onUpdate(updated: equal(to: []), inserted: equal(to: [transaction]))
 
         verifyNoMoreInteractions(mockOutputAddressExtractor)
         verifyNoMoreInteractions(mockInputExtractor)
@@ -92,15 +97,12 @@ class TransactionProcessorTests: XCTestCase {
         let transaction = TestData.p2pkhTransaction
         transaction.isMine = true
 
-        try! realm.write {
-            realm.add(transaction)
-        }
-
-        transactionProcessor.process(transaction: transaction, realm: realm)
+        try! transactionProcessor.processOutgoing(transaction: transaction, realm: realm)
 
         verify(mockOutputExtractor).extract(transaction: equal(to: transaction))
         verify(mockLinker).handle(transaction: equal(to: transaction), realm: equal(to: realm))
 
+        verify(mockBlockchainDataListener).onUpdate(updated: equal(to: []), inserted: equal(to: [transaction]))
         verify(mockOutputAddressExtractor).extractOutputAddresses(transaction: equal(to: transaction))
         verify(mockInputExtractor).extract(transaction: equal(to: transaction))
     }
@@ -119,6 +121,8 @@ class TransactionProcessorTests: XCTestCase {
 
         verify(mockOutputExtractor, never()).extract(transaction: equal(to: transaction))
         verify(mockLinker, never()).handle(transaction: equal(to: transaction), realm: equal(to: realm))
+
+        verify(mockBlockchainDataListener).onUpdate(updated: equal(to: [transaction]), inserted: equal(to: []))
 
         let realmTransactions = realm.objects(Transaction.self)
         XCTAssertEqual(realmTransactions.count, 1)
@@ -145,6 +149,8 @@ class TransactionProcessorTests: XCTestCase {
         }
 
         let realmTransactions = realm.objects(Transaction.self).sorted(byKeyPath: "order")
+
+        verify(mockBlockchainDataListener).onUpdate(updated: equal(to: [transactions[1], transactions[3]]), inserted: equal(to: [transactions[0], transactions[2]]))
 
         XCTAssertEqual(realmTransactions.count, 4)
         for (i, transaction) in transactions.enumerated() {
@@ -177,6 +183,8 @@ class TransactionProcessorTests: XCTestCase {
 
         let realmTransactions = realm.objects(Transaction.self).sorted(byKeyPath: "order")
 
+        verify(mockBlockchainDataListener).onUpdate(updated: equal(to: [transactions[1], transactions[3]]), inserted: equal(to: [transactions[0], transactions[2]]))
+
         XCTAssertEqual(realmTransactions.count, 4)
         for (i, transaction) in transactions.enumerated() {
             XCTAssertEqual(realmTransactions[i].block?.reversedHeaderHashHex, block.reversedHeaderHashHex)
@@ -199,6 +207,9 @@ class TransactionProcessorTests: XCTestCase {
         verify(mockLinker).handle(transaction: equal(to: transaction), realm: equal(to: realm))
 
         let realmTransactions = realm.objects(Transaction.self)
+
+        verify(mockBlockchainDataListener).onUpdate(updated: equal(to: []), inserted: equal(to: [transaction]))
+
         XCTAssertEqual(realmTransactions.count, 1)
         XCTAssertEqual(realmTransactions.first!.dataHash, transaction.dataHash)
         XCTAssertEqual(realmTransactions.first!.status, TransactionStatus.relayed)
@@ -215,6 +226,8 @@ class TransactionProcessorTests: XCTestCase {
 
         verify(mockOutputExtractor).extract(transaction: equal(to: transaction))
         verify(mockLinker).handle(transaction: equal(to: transaction), realm: equal(to: realm))
+
+        verifyNoMoreInteractions(mockBlockchainDataListener)
 
         let realmTransactions = realm.objects(Transaction.self)
         XCTAssertEqual(realmTransactions.count, 0)
@@ -240,6 +253,8 @@ class TransactionProcessorTests: XCTestCase {
 
         verify(mockOutputExtractor).extract(transaction: equal(to: transaction))
         verify(mockLinker).handle(transaction: equal(to: transaction), realm: equal(to: realm))
+
+        verify(mockBlockchainDataListener).onUpdate(updated: equal(to: []), inserted: equal(to: [transaction]))
 
         let realmTransactions = realm.objects(Transaction.self)
         XCTAssertEqual(realmTransactions.count, 1)
@@ -271,6 +286,8 @@ class TransactionProcessorTests: XCTestCase {
         verify(mockOutputExtractor).extract(transaction: equal(to: transaction))
         verify(mockLinker).handle(transaction: equal(to: transaction), realm: equal(to: realm))
 
+        verify(mockBlockchainDataListener).onUpdate(updated: equal(to: []), inserted: equal(to: [transaction]))
+
         let realmTransactions = realm.objects(Transaction.self)
         XCTAssertEqual(realmTransactions.count, 1)
         XCTAssertEqual(realmTransactions.first!.dataHash, transaction.dataHash)
@@ -297,6 +314,8 @@ class TransactionProcessorTests: XCTestCase {
         verify(mockOutputExtractor).extract(transaction: equal(to: transaction))
         verify(mockLinker).handle(transaction: equal(to: transaction), realm: equal(to: realm))
 
+        verify(mockBlockchainDataListener).onUpdate(updated: equal(to: []), inserted: equal(to: [transaction]))
+
         let realmTransactions = realm.objects(Transaction.self)
         XCTAssertEqual(realmTransactions.count, 1)
         XCTAssertEqual(realmTransactions.first!.dataHash, transaction.dataHash)
@@ -319,6 +338,8 @@ class TransactionProcessorTests: XCTestCase {
                 XCTFail("Shouldn't throw exception")
             }
         }
+
+        verifyNoMoreInteractions(mockBlockchainDataListener)
 
         verify(mockOutputExtractor).extract(transaction: equal(to: transaction))
         verify(mockLinker).handle(transaction: equal(to: transaction), realm: equal(to: realm))
@@ -348,6 +369,8 @@ class TransactionProcessorTests: XCTestCase {
                         calledTransactions = []
 
                         try! transactionProcessor.process(transactions: [transactions[i], transactions[j], transactions[k], transactions[l]], inBlock: nil, skipCheckBloomFilter: false, realm: realm)
+
+                        verifyNoMoreInteractions(mockBlockchainDataListener)
 
                         for (m, transaction) in calledTransactions.enumerated() {
                             XCTAssertEqual(transaction.reversedHashHex, transactions[m].reversedHashHex)

--- a/HSBitcoinKitDemo/HSBitcoinKitDemo/BalanceController.swift
+++ b/HSBitcoinKitDemo/HSBitcoinKitDemo/BalanceController.swift
@@ -25,7 +25,16 @@ class BalanceController: UIViewController {
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Logout", style: .plain, target: self, action: #selector(logout))
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Start", style: .plain, target: self, action: #selector(start))
+        navigationItem.rightBarButtonItem?.isEnabled = false
 
+        Manager.shared.kitInitializationCompleted.subscribe(onNext: { [weak self] status in
+            if status {
+                self?.initializeBitcoinKit()
+            }
+        }).disposed(by: disposeBag)
+    }
+
+    func initializeBitcoinKit() {
         let bitcoinKit = Manager.shared.bitcoinKit!
 
         update(balance: bitcoinKit.balance)
@@ -45,6 +54,8 @@ class BalanceController: UIViewController {
         Manager.shared.lastBlockInfoSubject.observeOn(MainScheduler.instance).subscribe(onNext: { [weak self] info in
             self?.update(lastBlockInfo: info)
         }).disposed(by: disposeBag)
+
+        navigationItem.rightBarButtonItem?.isEnabled = true
     }
 
     @objc func logout() {
@@ -58,10 +69,12 @@ class BalanceController: UIViewController {
     }
 
     @objc func start() {
-        do {
-            try Manager.shared.bitcoinKit.start()
-        } catch {
-            print("Start Error: \(error)")
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try Manager.shared.bitcoinKit.start()
+            } catch {
+                print("Start Error: \(error)")
+            }
         }
     }
 

--- a/HSBitcoinKitDemo/HSBitcoinKitDemo/Manager.swift
+++ b/HSBitcoinKitDemo/HSBitcoinKitDemo/Manager.swift
@@ -12,6 +12,8 @@ class Manager {
 
     var bitcoinKit: BitcoinKit!
 
+    let kitInitializationCompleted = BehaviorSubject<Bool>(value: false)
+
     let balanceSubject = PublishSubject<Int>()
     let lastBlockInfoSubject = PublishSubject<BlockInfo>()
     let progressSubject = PublishSubject<BitcoinKit.KitState>()
@@ -36,12 +38,18 @@ class Manager {
         }
 
         clearWords()
+
+        kitInitializationCompleted.onNext(false)
         bitcoinKit = nil
     }
 
     private func initWalletKit(words: [String]) {
-        bitcoinKit = BitcoinKit(withWords: words, coin: coin, walletId: "SomeId", confirmationsThreshold: 1)
-        bitcoinKit.delegate = self
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.bitcoinKit = BitcoinKit(withWords: words, coin: self.coin, walletId: "SomeId", confirmationsThreshold: 1)
+            self.bitcoinKit.delegate = self
+
+            self.kitInitializationCompleted.onNext(true)
+        }
     }
 
     private var savedWords: [String]? {

--- a/HSBitcoinKitDemo/HSBitcoinKitDemo/Manager.swift
+++ b/HSBitcoinKitDemo/HSBitcoinKitDemo/Manager.swift
@@ -65,8 +65,12 @@ class Manager {
 
 extension Manager: BitcoinKitDelegate {
 
-    public func transactionsUpdated(bitcoinKit: BitcoinKit, inserted: [TransactionInfo], updated: [TransactionInfo], deleted: [Int]) {
+    public func transactionsUpdated(bitcoinKit: BitcoinKit, inserted: [TransactionInfo], updated: [TransactionInfo]) {
         transactionsSubject.onNext(())
+    }
+
+    public func transactionsDeleted(hashes: [String]) {
+        // transactionsSubject.onNext(())
     }
 
     public func balanceUpdated(bitcoinKit: BitcoinKit, balance: Int) {

--- a/README.md
+++ b/README.md
@@ -192,9 +192,14 @@ class Manager {
 
 extension Manager: BitcoinKitDelegate {
 
-    public func transactionsUpdated(bitcoinKit: BitcoinKit, inserted: [TransactionInfo], updated: [TransactionInfo], deleted: [Int]) {
+    public func transactionsUpdated(bitcoinKit: BitcoinKit, inserted: [TransactionInfo], updated: [TransactionInfo]) {
 		// do something with transactions
     }
+
+public func transactionsDeleted(hashes: [String]) {
+    // do something with transactions
+    }
+
 
     public func balanceUpdated(bitcoinKit: BitcoinKit, balance: Int) {
 		// do something with balance
@@ -214,6 +219,11 @@ extension Manager: BitcoinKitDelegate {
     }
 
 }
+```
+Listener events are run in a dedicated background thread. It can be switched to main thread by setting the  ```delegateQueue``` property to ```DispatchQueue.main```
+
+```swift
+bitcoinKit.delegateQueue = DispatchQueue.main
 ```
 
 ## Prerequisites


### PR DESCRIPTION
- Change BitcoinKit interface. Separate handle deleted transactions and updated/inserted transactions
- Add BlockchainDataListener for transaction and block updates
- Incapsulate proccess logic in TransactionProcessor class

closes #237 
closes #245 