### PR TITLE
Ignore duplicate primary blockHash when process inventory item

### DIFF
--- a/HSBitcoinKit/HSBitcoinKit/Network/Messages/InventoryMessage.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Network/Messages/InventoryMessage.swift
@@ -18,8 +18,14 @@ struct InventoryMessage: IMessage {
         count = byteStream.read(VarInt.self)
 
         var inventoryItems = [InventoryItem]()
+        var seen: [String: Bool] = [:]
+
         for _ in 0..<Int(count.underlyingValue) {
-            inventoryItems.append(InventoryItem(byteStream: byteStream))
+            let item = InventoryItem(byteStream: byteStream)
+
+            if seen.updateValue(true, forKey: item.hash.reversedHex) == nil {
+                inventoryItems.append(item)
+            }
         }
 
         self.inventoryItems = inventoryItems

--- a/HSBitcoinKit/HSBitcoinKit/Network/Messages/InventoryMessage.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Network/Messages/InventoryMessage.swift
@@ -18,12 +18,13 @@ struct InventoryMessage: IMessage {
         count = byteStream.read(VarInt.self)
 
         var inventoryItems = [InventoryItem]()
-        var seen: [String: Bool] = [:]
+        var seen = Set<String>()
 
         for _ in 0..<Int(count.underlyingValue) {
             let item = InventoryItem(byteStream: byteStream)
 
-            if seen.updateValue(true, forKey: item.hash.reversedHex) == nil {
+            if !seen.contains(item.hash.reversedHex) {
+                seen.update(with: item.hash.reversedHex)
                 inventoryItems.append(item)
             }
         }

--- a/HSBitcoinKit/HSBitcoinKit/Network/Messages/InventoryMessage.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Network/Messages/InventoryMessage.swift
@@ -23,10 +23,11 @@ struct InventoryMessage: IMessage {
         for _ in 0..<Int(count.underlyingValue) {
             let item = InventoryItem(byteStream: byteStream)
 
-            if !seen.contains(item.hash.reversedHex) {
-                seen.update(with: item.hash.reversedHex)
-                inventoryItems.append(item)
+            guard !seen.contains(item.hash.reversedHex) else {
+                continue
             }
+            seen.insert(item.hash.reversedHex)
+            inventoryItems.append(item)
         }
 
         self.inventoryItems = inventoryItems

--- a/HSBitcoinKit/HSBitcoinKit/Transactions/TransactionProcessor.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Transactions/TransactionProcessor.swift
@@ -52,7 +52,7 @@ extension TransactionProcessor: ITransactionProcessor {
         for (index, transaction) in transactions.inTopologicalOrder().enumerated() {
             if let existingTransaction = realm.objects(Transaction.self).filter("reversedHashHex = %@", transaction.reversedHashHex).first {
                 relay(transaction: existingTransaction, withOrder: index, inBlock: block)
-                updated.append(transaction)
+                updated.append(existingTransaction)
                 continue
             }
 

--- a/HSBitcoinKit/HSBitcoinKitTests/Transactions/TransactionProcessorTests.swift
+++ b/HSBitcoinKit/HSBitcoinKitTests/Transactions/TransactionProcessorTests.swift
@@ -109,6 +109,9 @@ class TransactionProcessorTests: XCTestCase {
 
     func testProcessTransactions_TransactionExists() {
         let transaction = TestData.p2pkhTransaction
+        let incomingTransaction = TestData.p2pkhTransaction
+        incomingTransaction.status = .new
+
         transaction.status = .new
 
         try! realm.write {
@@ -116,7 +119,7 @@ class TransactionProcessorTests: XCTestCase {
         }
 
         try! realm.write {
-            try! transactionProcessor.process(transactions: [transaction], inBlock: nil, skipCheckBloomFilter: false, realm: realm)
+            try! transactionProcessor.process(transactions: [incomingTransaction], inBlock: nil, skipCheckBloomFilter: false, realm: realm)
         }
 
         verify(mockOutputExtractor, never()).extract(transaction: equal(to: transaction))

--- a/HSBitcoinKitDemo/HSBitcoinKitDemo/BalanceController.swift
+++ b/HSBitcoinKitDemo/HSBitcoinKitDemo/BalanceController.swift
@@ -29,7 +29,9 @@ class BalanceController: UIViewController {
 
         Manager.shared.kitInitializationCompleted.subscribe(onNext: { [weak self] status in
             if status {
-                self?.initializeBitcoinKit()
+                DispatchQueue.main.async {
+                    self?.initializeBitcoinKit()
+                }
             }
         }).disposed(by: disposeBag)
     }


### PR DESCRIPTION
- Fix bug with wrong update transaction until process existing tx.
- Initialize bitcoinKit on main thread (UI update)

closes #169 