### PR TITLE
Fix BTC stop syncing when api sync failed

### DIFF
--- a/HSBitcoinKit/HSBitcoinKit.xcodeproj/project.pbxproj
+++ b/HSBitcoinKit/HSBitcoinKit.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		58AAA317128E10EE72E0D0B1 /* BlockHashFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AAAD725CB287055DC7CCE5 /* BlockHashFetcherTests.swift */; };
 		58AAA3206EF27B4A13AD30E4 /* EDAValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AAA454CCE3AE60B70E8DAF /* EDAValidatorTests.swift */; };
 		58AAA321A8780859892D0C73 /* TransactionOutputExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AAAE28D740FD1FCF9DC1B2 /* TransactionOutputExtractorTests.swift */; };
+		58AAA32402EFCE6218A9D082 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AAA6603AEA2159F6126D10 /* Signal.swift */; };
 		58AAA3492A592C937473454F /* ScriptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AAAF2482982ED7215EEBF9 /* ScriptBuilder.swift */; };
 		58AAA36E48DB45B72112973B /* TransactionCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AAAC66042A881E2F74AFD6 /* TransactionCreator.swift */; };
 		58AAA3A0474719B721A0E877 /* PaymentAddressParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AAA3FBA5C8CE3D9C678F5D /* PaymentAddressParserTests.swift */; };
@@ -366,6 +367,7 @@
 		58AAA55E49708A950F951E2D /* BitcoinAddressSelector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BitcoinAddressSelector.swift; sourceTree = "<group>"; };
 		58AAA5EE018C74544938121F /* MerkleBlockValidatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MerkleBlockValidatorTests.swift; sourceTree = "<group>"; };
 		58AAA62C7C37CA2D7FD668B5 /* TransactionOutputExtractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionOutputExtractor.swift; sourceTree = "<group>"; };
+		58AAA6603AEA2159F6126D10 /* Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Signal.swift; sourceTree = "<group>"; };
 		58AAA674EE7C1523F42648DD /* TransactionOutputAddressExtractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionOutputAddressExtractor.swift; sourceTree = "<group>"; };
 		58AAA684704A912E02B1138B /* FeeRateManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeeRateManager.swift; sourceTree = "<group>"; };
 		58AAA6970A592ECB1C6E73D3 /* LegacyDifficultyAdjustmentValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyDifficultyAdjustmentValidator.swift; sourceTree = "<group>"; };
@@ -490,6 +492,7 @@
 				2FA5D859C070F9718CACF08F /* KitStateProvider.swift */,
 				2FA5D9929AB239235F9B6895 /* Logger.swift */,
 				11B3501384C4274027587EB4 /* Protocols.swift */,
+				58AAA6603AEA2159F6126D10 /* Signal.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1472,6 +1475,7 @@
 				58AAA445FA83E69172FFC1ED /* BlockHashFetcher.swift in Sources */,
 				58AAA572F80B63848F95B065 /* BlockHashFetcherHelper.swift in Sources */,
 				3C7B913CB012F68959606805 /* BCoinApiManager.swift in Sources */,
+				58AAA32402EFCE6218A9D082 /* Signal.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HSBitcoinKit/HSBitcoinKit/Core/BitcoinKit.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/BitcoinKit.swift
@@ -148,7 +148,7 @@ public class BitcoinKit {
         peerGroup = PeerGroup(factory: factory, network: network, listener: kitStateProvider, reachabilityManager: reachabilityManager, peerHostManager: peerHostManager, bloomFilterManager: bloomFilterManager, logger: logger)
 
         addressManager = AddressManager(realmFactory: realmFactory, hdWallet: hdWallet, addressConverter: addressConverter)
-        initialSyncer = InitialSyncer(realmFactory: realmFactory, listener: kitStateProvider, hdWallet: hdWallet, stateManager: stateManager, blockDiscovery: blockDiscovery, addressManager: addressManager, factory: factory, peerGroup: peerGroup, logger: logger)
+        initialSyncer = InitialSyncer(realmFactory: realmFactory, listener: kitStateProvider, hdWallet: hdWallet, stateManager: stateManager, blockDiscovery: blockDiscovery, addressManager: addressManager, factory: factory, peerGroup: peerGroup, reachabilityManager: reachabilityManager, logger: logger)
 
         realmStorage = RealmStorage(realmFactory: realmFactory)
 
@@ -201,7 +201,7 @@ extension BitcoinKit {
     }
 
     public func clear() throws {
-        peerGroup.stop()
+        initialSyncer.stop()
 
         let realm = realmFactory.realm
 

--- a/HSBitcoinKit/HSBitcoinKit/Core/DataProvider.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/DataProvider.swift
@@ -20,7 +20,13 @@ class DataProvider {
 
     private let balanceUpdateSubject = PublishSubject<Void>()
 
-    public var balance: Int = 0
+    public var balance: Int = 0 {
+        didSet {
+            if !(oldValue == balance) {
+                delegate?.balanceUpdated(balance: balance)
+            }
+        }
+    }
     public var lastBlockInfo: BlockInfo? = nil
 
     weak var delegate: IDataProviderDelegate?
@@ -40,7 +46,6 @@ class DataProvider {
 
         balanceUpdateSubject.debounce(debounceTime, scheduler: ConcurrentDispatchQueueScheduler(qos: .background)).subscribe(onNext: {
             self.balance = unspentOutputProvider.balance
-            self.delegate?.balanceUpdated(balance: self.balance)
         }).disposed(by: disposeBag)
     }
 

--- a/HSBitcoinKit/HSBitcoinKit/Core/Protocols.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/Protocols.swift
@@ -40,8 +40,8 @@ protocol IApiConfigProvider {
 }
 
 protocol IReachabilityManager {
-    var subject: PublishSubject<Bool> { get set }
-    func reachable() -> Bool
+    var isReachable: Bool { get }
+    var reachabilitySignal: Signal { get }
 }
 
 protocol IPeriodicTimer {
@@ -231,6 +231,7 @@ protocol IBCoinApiManager {
 
 protocol IInitialSyncer {
     func sync() throws
+    func stop()
 }
 
 protocol IBlockHashFetcher {

--- a/HSBitcoinKit/HSBitcoinKit/Core/Signal.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/Signal.swift
@@ -1,0 +1,11 @@
+import RxSwift
+
+typealias Signal = PublishSubject<Void>
+
+extension PublishSubject where Element == Void {
+
+    func notify() {
+        self.onNext(())
+    }
+
+}

--- a/HSBitcoinKit/HSBitcoinKitTests/Core/DataProviderTests.swift
+++ b/HSBitcoinKit/HSBitcoinKitTests/Core/DataProviderTests.swift
@@ -224,7 +224,6 @@ class DataProviderTests: XCTestCase {
         waitForMainQueue()
 
         verify(mockDataProviderDelegate).lastBlockInfoUpdated(lastBlockInfo: equal(to: blockInfo))
-        verify(mockDataProviderDelegate).balanceUpdated(balance: equal(to: 0))
         XCTAssertEqual(dataProvider.balance, 0)
         XCTAssertEqual(dataProvider.lastBlockInfo, blockInfo)
     }

--- a/HSBitcoinKit/HSBitcoinKitTests/Network/New Group/PeerGroupTests/IPeerGroupTests.swift
+++ b/HSBitcoinKit/HSBitcoinKitTests/Network/New Group/PeerGroupTests/IPeerGroupTests.swift
@@ -84,7 +84,10 @@ class IPeerGroupTests: PeerGroupTests {
         peerGroup.start()
         waitForMainQueue()
 
-        subject.onNext(true)
+        subject.onNext(())
+        stub(mockReachabilityManager) { mock in
+            when(mock.isReachable.get).thenReturn(true)
+        }
         verify(mockBlockSyncer).prepareForDownload()
         verify(mockListener).syncStarted()
     }
@@ -93,7 +96,11 @@ class IPeerGroupTests: PeerGroupTests {
         peerGroup.start()
         waitForMainQueue()
 
-        subject.onNext(false)
+        stub(mockReachabilityManager) { mock in
+            when(mock.isReachable.get).thenReturn(false)
+        }
+        subject.onNext(())
+
         verify(mockPeerManager).disconnectAll()
         verify(mockListener).syncStopped()
     }
@@ -101,7 +108,7 @@ class IPeerGroupTests: PeerGroupTests {
 
     func testStart_NetworkIsNotReachable() {
         stub(mockReachabilityManager) { mock in
-            when(mock.reachable()).thenReturn(false)
+            when(mock.isReachable.get).thenReturn(false)
         }
 
         peerGroup.start()

--- a/HSBitcoinKit/HSBitcoinKitTests/Network/New Group/PeerGroupTests/PeerDelegateTests.swift
+++ b/HSBitcoinKit/HSBitcoinKitTests/Network/New Group/PeerGroupTests/PeerDelegateTests.swift
@@ -351,7 +351,7 @@ class PeerDelegateTests: PeerGroupTests {
         let peer = peers["0"]!
 
         stub(mockReachabilityManager) { mock in
-            when(mock.reachable()).thenReturn(true)
+            when(mock.isReachable.get).thenReturn(true)
         }
         stub(mockPeerManager) { mock in
             when(mock.syncPeer.set(any())).thenDoNothing()
@@ -402,7 +402,7 @@ class PeerDelegateTests: PeerGroupTests {
         let peer = peers["0"]!
 
         stub(mockReachabilityManager) { mock in
-            when(mock.reachable()).thenReturn(true)
+            when(mock.isReachable.get).thenReturn(true)
         }
         stub(mockPeerManager) { mock in
             when(mock.syncPeerIs(peer: any())).thenReturn(false)
@@ -442,7 +442,7 @@ class PeerDelegateTests: PeerGroupTests {
         let peer = peers["0"]!
 
         stub(mockReachabilityManager) { mock in
-            when(mock.reachable()).thenReturn(false)
+            when(mock.isReachable.get).thenReturn(false)
         }
         stub(mockPeerManager) { mock in
             when(mock.syncPeerIs(peer: any())).thenReturn(false)
@@ -466,7 +466,7 @@ class PeerDelegateTests: PeerGroupTests {
         let error = PeerConnection.PeerConnectionError.connectionClosedByPeer
 
         stub(mockReachabilityManager) { mock in
-            when(mock.reachable()).thenReturn(false)
+            when(mock.isReachable.get).thenReturn(false)
         }
         stub(mockPeerManager) { mock in
             when(mock.syncPeerIs(peer: any())).thenReturn(false)

--- a/HSBitcoinKit/HSBitcoinKitTests/Network/New Group/PeerGroupTests/PeerGroupTests.swift
+++ b/HSBitcoinKit/HSBitcoinKitTests/Network/New Group/PeerGroupTests/PeerGroupTests.swift
@@ -22,7 +22,7 @@ class PeerGroupTests: XCTestCase {
 
     internal var peersCount = 3
     internal var peers: [String: MockIPeer]!
-    internal var subject: PublishSubject<Bool>!
+    internal var subject: PublishSubject<()>!
 
     override func setUp() {
         super.setUp()
@@ -37,7 +37,7 @@ class PeerGroupTests: XCTestCase {
         mockBlockSyncer = MockIBlockSyncer()
         mockTransactionSyncer = MockITransactionSyncer()
         peers = [String: MockIPeer]()
-        subject = PublishSubject<Bool>()
+        subject = PublishSubject<()>()
 
         for host in 0..<4 {
             let hostString = String(host)
@@ -56,8 +56,8 @@ class PeerGroupTests: XCTestCase {
             when(mock.syncFinished()).thenDoNothing()
         }
         stub(mockReachabilityManager) { mock in
-            when(mock.subject.get).thenReturn(subject)
-            when(mock.reachable()).thenReturn(true)
+            when(mock.reachabilitySignal.get).thenReturn(subject)
+            when(mock.isReachable.get).thenReturn(true)
         }
         stub(mockPeerHostManager) { mock in
             when(mock.delegate.set(any())).thenDoNothing()

--- a/HSBitcoinKitDemo/HSBitcoinKitDemo/Manager.swift
+++ b/HSBitcoinKitDemo/HSBitcoinKitDemo/Manager.swift
@@ -44,12 +44,10 @@ class Manager {
     }
 
     private func initWalletKit(words: [String]) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            self.bitcoinKit = BitcoinKit(withWords: words, coin: self.coin, walletId: "SomeId", confirmationsThreshold: 1)
-            self.bitcoinKit.delegate = self
+        bitcoinKit = BitcoinKit(withWords: words, coin: self.coin, walletId: "SomeId", confirmationsThreshold: 1)
+        bitcoinKit.delegate = self
 
-            self.kitInitializationCompleted.onNext(true)
-        }
+        kitInitializationCompleted.onNext(true)
     }
 
     private var savedWords: [String]? {


### PR DESCRIPTION
- Add network handling to initial syncer
- Add new reachability manager
- Add stop method to initial syncer, stop peer group throw it
- Ignore signal to update balance if it's state not changed
- Make test project create bitcoinKit on main thread

closes #243 