### PR TITLE
Fix issue with syncing expired peers

### DIFF
--- a/HSBitcoinKit/HSBitcoinKit/Blocks/BlockSyncer.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Blocks/BlockSyncer.swift
@@ -138,7 +138,7 @@ extension BlockSyncer: IBlockSyncer {
         }
 
         if blockLocatorHashes.isEmpty {
-            realm.objects(Block.self).sorted(byKeyPath: "height", ascending: false).prefix(10).forEach { block in
+            realm.objects(Block.self).filter("height > %@", network.checkpointBlock.height).sorted(byKeyPath: "height", ascending: false).prefix(10).forEach { block in
                 blockLocatorHashes.append(block.headerHash)
             }
         }


### PR DESCRIPTION
- Don't request blocks earlier than local checkpoint block

closes #258