### PR TITLE
Fix potential bug that may cause PeerGroup sync loop (#273)

### DIFF
--- a/HSBitcoinKit/HSBitcoinKit/Core/Protocols.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Core/Protocols.swift
@@ -127,6 +127,7 @@ protocol IPeerManager: class {
     func connected() -> [IPeer]
     func nonSyncedPeer() -> IPeer?
     func syncPeerIs(peer: IPeer) -> Bool
+    func halfIsSynced() -> Bool
 }
 
 protocol IPeer: class {

--- a/HSBitcoinKit/HSBitcoinKit/Network/Peer/PeerManager.swift
+++ b/HSBitcoinKit/HSBitcoinKit/Network/Peer/PeerManager.swift
@@ -52,4 +52,11 @@ class PeerManager: IPeerManager {
     func syncPeerIs(peer: IPeer) -> Bool {
         return peer.equalTo(syncPeer)
     }
+
+    func halfIsSynced() -> Bool {
+        let syncedPeersCount = peers.filter({ $0.connected && $0.synced }).count
+
+        return syncedPeersCount >= peers.count / 2
+    }
+
 }

--- a/HSBitcoinKit/HSBitcoinKitTests/Managers/FeeRateManagerTests.swift
+++ b/HSBitcoinKit/HSBitcoinKitTests/Managers/FeeRateManagerTests.swift
@@ -32,9 +32,7 @@ class FeeRateManagerTests: XCTestCase {
             when(mock.save(feeRate: any())).thenDoNothing()
         }
         stub(mockSyncer) { mock in
-            when(mock.sync()).then {
-                print("sdfsdfdssdf")
-            }
+            when(mock.sync()).thenDoNothing()
             when(mock.delegate.set(any())).thenDoNothing()
         }
         stub(mockReachabilityManager) { mock in

--- a/HSBitcoinKit/HSBitcoinKitTests/Network/New Group/PeerGroupTests/IPeerGroupTests.swift
+++ b/HSBitcoinKit/HSBitcoinKitTests/Network/New Group/PeerGroupTests/IPeerGroupTests.swift
@@ -133,7 +133,7 @@ class IPeerGroupTests: PeerGroupTests {
         }
         stub(mockPeerManager) { mock in
             when(mock.connected()).thenReturn([peer])
-            when(mock.nonSyncedPeer()).thenReturn(nil)
+            when(mock.halfIsSynced()).thenReturn(true)
             when(mock.someReadyPeers()).thenReturn([peer])
         }
 
@@ -152,7 +152,7 @@ class IPeerGroupTests: PeerGroupTests {
         }
         stub(mockPeerManager) { mock in
             when(mock.connected()).thenReturn([])
-            when(mock.nonSyncedPeer()).thenReturn(nil)
+            when(mock.halfIsSynced()).thenReturn(true)
             when(mock.someReadyPeers()).thenReturn([peer])
         }
 
@@ -169,7 +169,7 @@ class IPeerGroupTests: PeerGroupTests {
         verify(peer, never()).add(task: any())
     }
 
-    func testSendPendingTransactions_PeersAreNotSynced() {
+    func testSendPendingTransactions_MajorityOfPeersAreNotSynced() {
         let transaction = TestData.p2pkTransaction
         let peer = peers["0"]!
 
@@ -178,7 +178,7 @@ class IPeerGroupTests: PeerGroupTests {
         }
         stub(mockPeerManager) { mock in
             when(mock.connected()).thenReturn([peer])
-            when(mock.nonSyncedPeer()).thenReturn(peer)
+            when(mock.halfIsSynced()).thenReturn(false)
             when(mock.someReadyPeers()).thenReturn([peer])
         }
 
@@ -204,7 +204,7 @@ class IPeerGroupTests: PeerGroupTests {
         }
         stub(mockPeerManager) { mock in
             when(mock.connected()).thenReturn([peer])
-            when(mock.nonSyncedPeer()).thenReturn(nil)
+            when(mock.halfIsSynced()).thenReturn(true)
             when(mock.someReadyPeers()).thenReturn([])
         }
 
@@ -223,7 +223,7 @@ class IPeerGroupTests: PeerGroupTests {
         }
         stub(mockPeerManager) { mock in
             when(mock.connected()).thenReturn([peer])
-            when(mock.nonSyncedPeer()).thenReturn(nil)
+            when(mock.halfIsSynced()).thenReturn(true)
             when(mock.someReadyPeers()).thenReturn([peer])
         }
 
@@ -239,7 +239,7 @@ class IPeerGroupTests: PeerGroupTests {
         }
         stub(mockPeerManager) { mock in
             when(mock.connected()).thenReturn([])
-            when(mock.nonSyncedPeer()).thenReturn(nil)
+            when(mock.halfIsSynced()).thenReturn(true)
             when(mock.someReadyPeers()).thenReturn([peer])
         }
 
@@ -263,7 +263,7 @@ class IPeerGroupTests: PeerGroupTests {
         }
         stub(mockPeerManager) { mock in
             when(mock.connected()).thenReturn([peer])
-            when(mock.nonSyncedPeer()).thenReturn(peer)
+            when(mock.halfIsSynced()).thenReturn(false)
             when(mock.someReadyPeers()).thenReturn([peer])
         }
 

--- a/HSBitcoinKit/HSBitcoinKitTests/Network/New Group/PeerManagerTests.swift
+++ b/HSBitcoinKit/HSBitcoinKitTests/Network/New Group/PeerManagerTests.swift
@@ -91,6 +91,30 @@ class PeerManagerTests:XCTestCase {
         XCTAssertEqual(manager.syncPeerIs(peer: peer), false)
     }
 
+    func testHalfIsSynced() {
+        let _ = addPeer(host: "0", connected: true, synced: true)
+        let _ = addPeer(host: "1", connected: true, synced: true)
+        let _ = addPeer(host: "2", connected: false, synced: false)
+        let _ = addPeer(host: "3", connected: false, synced: true)
+
+        XCTAssertEqual(manager.halfIsSynced(), true)
+    }
+
+    func testHalfIsSynced_MoreThanHalf() {
+        let _ = addPeer(host: "0", connected: true, synced: true)
+
+        XCTAssertEqual(manager.halfIsSynced(), true)
+    }
+
+    func testHalfIsSynced_LessThanHalf() {
+        print("ere")
+        let _ = addPeer(host: "0", connected: true, synced: true)
+        let _ = addPeer(host: "1", connected: true, synced: false)
+        let _ = addPeer(host: "2", connected: false, synced: false)
+        let _ = addPeer(host: "3", connected: false, synced: true)
+
+        XCTAssertEqual(manager.halfIsSynced(), false)
+    }
 
     private func addPeer(host: String, ready: Bool = false, connected: Bool = false, synced: Bool = false) -> MockIPeer {
         let peer = MockIPeer()


### PR DESCRIPTION
- PeerGroup#downloadBlockchain(peer:) doesn't trigger next iteration unless currentPeer is syncPeer
- PeerGroup#sendPendingTransactions() requires around half of peers to be connected and synced

closes #273 