### PR TITLE
Fix bug with updated checkpoint (#389)

### DIFF
--- a/BitcoinCore/BitcoinCore/Core/BitcoinCoreBuilder.swift
+++ b/BitcoinCore/BitcoinCore/Core/BitcoinCoreBuilder.swift
@@ -188,7 +188,7 @@ public class BitcoinCoreBuilder {
 
         let blockValidatorChain = BlockValidatorChain(proofOfWorkValidator: ProofOfWorkValidator(difficultyEncoder: DifficultyEncoder()))
         let blockchain = Blockchain(storage: storage, blockValidator: blockValidatorChain, factory: factory, listener: dataProvider)
-        let checkpointBlock = syncMode == .full ? network.bip44CheckpointBlock : network.lastCheckpointBlock
+        let checkpointBlock = BlockSyncer.checkpointBlock(network: network, syncMode: syncMode, storage: storage)
         let blockSyncer = BlockSyncer.instance(storage: storage, checkpointBlock: checkpointBlock, factory: factory, listener: kitStateProvider, transactionProcessor: transactionProcessor, blockchain: blockchain, addressManager: addressManager, bloomFilterManager: bloomFilterManager, logger: logger)
         let initialBlockDownload = InitialBlockDownload(blockSyncer: blockSyncer, peerManager: peerManager, merkleBlockValidator: merkleBlockValidator, syncStateListener: kitStateProvider, logger: logger)
 


### PR DESCRIPTION
- If the last block in storage is older than the lastCheckpointBlock set to network, then it uses bip44CheckpointBlock

closes #389 