### PR TITLE
Bugfixes (#395)

### DIFF
--- a/BitcoinCore/BitcoinCore/Core/BitcoinCoreBuilder.swift
+++ b/BitcoinCore/BitcoinCore/Core/BitcoinCoreBuilder.swift
@@ -201,7 +201,7 @@ public class BitcoinCoreBuilder {
         let scriptBuilder = ScriptBuilderChain()
         let transactionBuilder = TransactionBuilder(unspentOutputSelector: unspentOutputSelector, unspentOutputProvider: unspentOutputProvider, addressManager: addressManager, addressConverter: addressConverter, inputSigner: inputSigner, scriptBuilder: scriptBuilder, factory: factory)
         let transactionSender = TransactionSender(transactionSyncer: transactionSyncer, peerManager: peerManager, initialBlockDownload: initialBlockDownload, syncedReadyPeerManager: syncedReadyPeerManager, logger: logger)
-        let transactionCreator = TransactionCreator(transactionBuilder: transactionBuilder, transactionProcessor: transactionProcessor, transactionSender: transactionSender)
+        let transactionCreator = TransactionCreator(transactionBuilder: transactionBuilder, transactionProcessor: transactionProcessor, transactionSender: transactionSender, bloomFilterManager: bloomFilterManager)
 
         let syncManager = SyncManager(reachabilityManager: reachabilityManager, initialSyncer: initialSyncer, peerGroup: peerGroup)
 

--- a/BitcoinCore/BitcoinCore/Managers/BloomFilterManager.swift
+++ b/BitcoinCore/BitcoinCore/Managers/BloomFilterManager.swift
@@ -66,11 +66,8 @@ extension BloomFilterManager: IBloomFilterManager {
         }
 
         if !elements.isEmpty {
-            let bloomFilter = factory.bloomFilter(withElements: elements)
-            if self.bloomFilter?.filter != bloomFilter.filter {
-                self.bloomFilter = bloomFilter
-                delegate?.bloomFilterUpdated(bloomFilter: bloomFilter)
-            }
+            bloomFilter = factory.bloomFilter(withElements: elements)
+            delegate?.bloomFilterUpdated(bloomFilter: bloomFilter!)
         }
     }
 

--- a/BitcoinCore/BitcoinCoreTests/Managers/BloomFilterManagerTests.swift
+++ b/BitcoinCore/BitcoinCoreTests/Managers/BloomFilterManagerTests.swift
@@ -164,25 +164,6 @@ class BloomFilterManagerTests: QuickSpec {
                     verify(mockBloomFilterManagerDelegate, never()).bloomFilterUpdated(bloomFilter: any())
                 }
             }
-
-            context("when no new element") {
-                it("doesn't trigger events") {
-                    stub(mockStorage) { mock in
-                        when(mock.publicKeys()).thenReturn([self.getPublicKey(withIndex: 0, chain: .external)])
-                        when(mock.outputsWithPublicKeys()).thenReturn([])
-                    }
-
-                    manager.regenerateBloomFilter()
-                    verify(mockBloomFilterManagerDelegate).bloomFilterUpdated(bloomFilter: any())
-                    reset(mockBloomFilterManagerDelegate)
-                    stub(mockBloomFilterManagerDelegate) { mock in
-                        when(mock.bloomFilterUpdated(bloomFilter: any())).thenDoNothing()
-                    }
-
-                    manager.regenerateBloomFilter()
-                    verify(mockBloomFilterManagerDelegate, never()).bloomFilterUpdated(bloomFilter: any())
-                }
-            }
         }
     }
 

--- a/BitcoinCore/BitcoinCoreTests/Transactions/TransactionCreatorTests.swift
+++ b/BitcoinCore/BitcoinCoreTests/Transactions/TransactionCreatorTests.swift
@@ -9,12 +9,13 @@ class TransactionCreatorTests: QuickSpec {
         let mockTransactionBuilder = MockITransactionBuilder()
         let mockTransactionProcessor = MockITransactionProcessor()
         let mockTransactionSender = MockITransactionSender()
+        let mockBloomFilterManager = MockIBloomFilterManager()
 
         var transactionCreator: TransactionCreator!
         let transaction = TestData.p2pkhTransaction
 
         afterEach {
-            reset(mockTransactionBuilder, mockTransactionProcessor, mockTransactionSender)
+            reset(mockTransactionBuilder, mockTransactionProcessor, mockTransactionSender, mockBloomFilterManager)
             transactionCreator = nil
         }
 
@@ -29,11 +30,40 @@ class TransactionCreatorTests: QuickSpec {
                 stub(mockTransactionSender) { mock in
                     when(mock.send(pendingTransaction: any())).thenDoNothing()
                 }
+                stub(mockBloomFilterManager) { mock in
+                    when(mock.regenerateBloomFilter()).thenDoNothing()
+                }
 
-                transactionCreator = TransactionCreator(transactionBuilder: mockTransactionBuilder, transactionProcessor: mockTransactionProcessor, transactionSender: mockTransactionSender)
+                transactionCreator = TransactionCreator(transactionBuilder: mockTransactionBuilder, transactionProcessor: mockTransactionProcessor, transactionSender: mockTransactionSender, bloomFilterManager: mockBloomFilterManager)
             }
 
-            context("when error") {
+            context("when BloomFilterManager.BloomFilterExpired error") {
+                beforeEach {
+                    stub(mockTransactionProcessor) { mock in
+                        when(mock.processCreated(transaction: any())).thenThrow(BloomFilterManager.BloomFilterExpired())
+                    }
+                    stub(mockTransactionSender) { mock in
+                        when(mock.verifyCanSend()).thenDoNothing()
+                    }
+
+                    try? transactionCreator.create(to: "", value: 0, feeRate: 0, senderPay: false)
+                }
+
+                it("does create transaction") {
+                    verify(mockTransactionBuilder).buildTransaction(value: any(), feeRate: any(), senderPay: any(), toAddress: any())
+                    verify(mockTransactionProcessor).processCreated(transaction: any())
+                }
+
+                it("does send transaction") {
+                    verify(mockTransactionSender).send(pendingTransaction: equal(to: transaction))
+                }
+
+                it("regenerates bloomfilter") {
+                    verify(mockBloomFilterManager).regenerateBloomFilter()
+                }
+            }
+
+            context("when other error") {
                 beforeEach {
                     stub(mockTransactionSender) { mock in
                         when(mock.verifyCanSend()).thenThrow(BitcoinCoreErrors.TransactionSendError.noConnectedPeers)
@@ -45,6 +75,10 @@ class TransactionCreatorTests: QuickSpec {
                 it("doesn't create transaction") {
                     verify(mockTransactionBuilder, never()).buildTransaction(value: any(), feeRate: any(), senderPay: any(), toAddress: any())
                     verify(mockTransactionProcessor, never()).processCreated(transaction: any())
+                }
+
+                it("doesn't regenerate bloomfilter") {
+                    verify(mockBloomFilterManager, never()).regenerateBloomFilter()
                 }
             }
 


### PR DESCRIPTION
- TransactionProcessor doesn't emit 'onUpdate' event to it's listener if transaction existed in DB with blockHash and it's coming from mempool
- TransactionProcessor trows exception in 'processCreated' if the transaction expires the bloom filter
- TransactionCreator regenerates bloomfilter if transaction processor throws BloomFilterExpired exception
- Remove bloomfilter.filter mutation check. It's useless, because filter is changed even if the elements are not changed

closes #395 