### PR TITLE
Bugfixes (#400, #401)

### DIFF
--- a/BitcoinCore/BitcoinCore/Blocks/InitialBlockDownload.swift
+++ b/BitcoinCore/BitcoinCore/Blocks/InitialBlockDownload.swift
@@ -33,7 +33,7 @@ public class InitialBlockDownload {
     public var syncedPeers = [IPeer]()
 
     init(blockSyncer: IBlockSyncer, peerManager: IPeerManager, merkleBlockValidator: IMerkleBlockValidator, syncStateListener: ISyncStateListener,
-         peersQueue: DispatchQueue = DispatchQueue(label: "PeerGroup Local Queue", qos: .userInitiated),
+         peersQueue: DispatchQueue = DispatchQueue(label: "InitialBlockDownload Local Queue", qos: .userInitiated),
          scheduler: SchedulerType = SerialDispatchQueueScheduler(qos: .background),
          logger: Logger? = nil) {
         self.blockSyncer = blockSyncer
@@ -125,7 +125,6 @@ public class InitialBlockDownload {
         syncedPeers.append(peer)
 
         subject.onNext(.onPeerSynced(peer: peer))
-        syncStateListener.syncFinished(all: allPeersSynced)
     }
 
     private func setPeerNotSynced(_ peer: IPeer) {
@@ -154,8 +153,8 @@ public class InitialBlockDownload {
                 .disposed(by: disposeBag)
     }
 
-    public var allPeersSynced: Bool {
-        return syncedPeers.count > 0 && syncedPeers.count >= peerManager.connected().count / 3
+    public var hasSyncedPeer: Bool {
+        return syncedPeers.count > 0
     }
 
 }

--- a/BitcoinCore/BitcoinCore/Core/KitStateProvider.swift
+++ b/BitcoinCore/BitcoinCore/Core/KitStateProvider.swift
@@ -27,10 +27,6 @@ extension KitStateProvider: ISyncStateListener {
         syncState = .notSynced
     }
 
-    func syncFinished(all: Bool) {
-        syncState = all ? .synced : .syncing(progress: 1)
-    }
-
     func initialBestBlockHeightUpdated(height: Int32) {
         initialBestBlockHeight = height
         currentBestBlockHeight = height
@@ -43,9 +39,18 @@ extension KitStateProvider: ISyncStateListener {
 
         let blocksDownloaded = currentBestBlockHeight - initialBestBlockHeight
         let allBlocksToDownload = maxBlockHeight - initialBestBlockHeight
+        var progress: Double = 0
 
-        if allBlocksToDownload > 0 && allBlocksToDownload > blocksDownloaded {
-            syncState = .syncing(progress: Double(blocksDownloaded) / Double(allBlocksToDownload))
+        if allBlocksToDownload <= 0 || allBlocksToDownload <= blocksDownloaded {
+            progress = 1.0
+        } else {
+            progress = Double(blocksDownloaded) / Double(allBlocksToDownload)
+        }
+
+        if progress >= 1 {
+            syncState = .synced
+        } else {
+            syncState = .syncing(progress: progress)
         }
     }
 

--- a/BitcoinCore/BitcoinCore/Core/Protocols.swift
+++ b/BitcoinCore/BitcoinCore/Core/Protocols.swift
@@ -225,7 +225,6 @@ protocol IConnectionTimeoutManager: class {
 protocol ISyncStateListener: class {
     func syncStarted()
     func syncStopped()
-    func syncFinished(all: Bool)
     func initialBestBlockHeightUpdated(height: Int32)
     func currentBestBlockHeightUpdated(height: Int32, maxBlockHeight: Int32)
 }
@@ -500,7 +499,7 @@ public protocol IMessageSerializer {
 }
 
 public protocol IInitialBlockDownload {
-    var allPeersSynced: Bool { get }
+    var hasSyncedPeer: Bool { get }
     var observable: Observable<InitialBlockDownloadEvent> { get }
     var syncedPeers: [IPeer] { get }
     func isSynced(peer: IPeer) -> Bool

--- a/BitcoinCore/BitcoinCore/Managers/SyncedReadyPeerManager.swift
+++ b/BitcoinCore/BitcoinCore/Managers/SyncedReadyPeerManager.swift
@@ -7,20 +7,25 @@ public class SyncedReadyPeerManager {
     private var peerStates = [String: Bool]()
 
     private let peerSyncedAndReadySubject = PublishSubject<IPeer>()
+    private let peersQueue: DispatchQueue
 
-    init(peerGroup: IPeerGroup, initialBlockDownload: IInitialBlockDownload) {
+    init(peerGroup: IPeerGroup, initialBlockDownload: IInitialBlockDownload,
+         peersQueue: DispatchQueue = DispatchQueue(label: "SyncedReadyPeerManager Local Queue", qos: .userInitiated)) {
         self.peerGroup = peerGroup
         self.initialBlockDownload = initialBlockDownload
+        self.peersQueue = peersQueue
     }
 
     private func set(state: Bool, to peer: IPeer) {
-        let oldState = peerStates[peer.host] ?? false
-        peerStates[peer.host] = state
+        peersQueue.async {
+            let oldState = self.peerStates[peer.host] ?? false
+            self.peerStates[peer.host] = state
 
-        if oldState != state {
-            if state {
-                peerSyncedAndReadySubject.onNext(peer)
-            } else {
+            if oldState != state {
+                if state {
+                    self.peerSyncedAndReadySubject.onNext(peer)
+                } else {
+                }
             }
         }
     }

--- a/BitcoinCore/BitcoinCore/Network/TransactionSender.swift
+++ b/BitcoinCore/BitcoinCore/Network/TransactionSender.swift
@@ -22,7 +22,7 @@ class TransactionSender {
             throw BitcoinCoreErrors.TransactionSendError.noConnectedPeers
         }
 
-        guard initialBlockDownload.allPeersSynced else {
+        guard initialBlockDownload.hasSyncedPeer else {
             throw BitcoinCoreErrors.TransactionSendError.peersNotSynced
         }
 


### PR DESCRIPTION
- Wrap peers dictionary in SyncedReadyPeersManager to dispatch queue
- 1 synced peer is enough for kit to be synced

closes #400 
closes #401 