### PR TITLE
Invalid transactions

### DIFF
--- a/BitcoinCashKit.swift.podspec
+++ b/BitcoinCashKit.swift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'BitcoinCashKit.swift'
   spec.module_name = "BitcoinCashKit"
-  spec.version = '0.9.0'
+  spec.version = '0.10.0'
   spec.summary = 'BitcoinCash library for Swift'
   spec.description = <<-DESC
                        BitcoinCashKit implements BitcoinCash protocol in Swift. It is an implementation of the BitcoinCash SPV protocol written (almost) entirely in swift.
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = '11.0'
   spec.swift_version = '5'
 
-  spec.dependency 'BitcoinCore.swift', '~> 0.9.0'
+  spec.dependency 'BitcoinCore.swift', '~> 0.10.0'
   spec.dependency 'HSCryptoKit', '~> 1.4'
   spec.dependency 'HSHDWalletKit', '~> 1.2'
   spec.dependency 'Alamofire', '~> 4.0'

--- a/BitcoinCashKit/BitcoinCashKit/Core/BitcoinCashKit.swift
+++ b/BitcoinCashKit/BitcoinCashKit/Core/BitcoinCashKit.swift
@@ -39,7 +39,7 @@ public class BitcoinCashKit: AbstractKit {
         }
         let initialSyncApi = InsightApi(url: initialSyncApiUrl)
 
-        let databaseFilePath = try DirectoryHelper.directoryURL(for: BitcoinCashKit.name).appendingPathComponent(BitcoinCashKit.databaseFileName(walletId: walletId, networkType: networkType)).path
+        let databaseFilePath = try DirectoryHelper.directoryURL(for: BitcoinCashKit.name).appendingPathComponent(BitcoinCashKit.databaseFileName(walletId: walletId, networkType: networkType, syncMode: syncMode)).path
         let storage = GrdbStorage(databaseFilePath: databaseFilePath)
         let paymentAddressParser = PaymentAddressParser(validScheme: validScheme, removeScheme: false)
 
@@ -85,19 +85,11 @@ public class BitcoinCashKit: AbstractKit {
 extension BitcoinCashKit {
 
     public static func clear(exceptFor walletIdsToExclude: [String] = []) throws {
-        var excludedFileNames = [String]()
-
-        for walletId in walletIdsToExclude {
-            for type in NetworkType.allCases {
-                excludedFileNames.append(databaseFileName(walletId: walletId, networkType: type))
-            }
-        }
-
-        try DirectoryHelper.removeAll(inDirectory: BitcoinCashKit.name, except: excludedFileNames)
+        try DirectoryHelper.removeAll(inDirectory: BitcoinCashKit.name, except: walletIdsToExclude)
     }
 
-    private static func databaseFileName(walletId: String, networkType: NetworkType) -> String {
-        "\(walletId)-\(networkType.rawValue)"
+    private static func databaseFileName(walletId: String, networkType: NetworkType, syncMode: BitcoinCore.SyncMode) -> String {
+        "\(walletId)-\(networkType.rawValue)-\(syncMode)"
     }
 
 }

--- a/BitcoinCore.swift.podspec
+++ b/BitcoinCore.swift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'BitcoinCore.swift'
   spec.module_name = "BitcoinCore"
-  spec.version = '0.9.0'
+  spec.version = '0.10.0'
   spec.summary = 'Core library Bitcoin derived wallets for Swift'
   spec.description = <<-DESC
                        BitcoinCore implements Bitcoin core protocol in Swift. It is an implementation of the Bitcoin SPV protocol written (almost) entirely in swift.

--- a/BitcoinCore/BitcoinCore.xcodeproj/project.pbxproj
+++ b/BitcoinCore/BitcoinCore.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		11B35EE64EEEE37EB90C5D14 /* PeerGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B359E44D75610DF2841327 /* PeerGroup.swift */; };
 		11B35F02260D5A21CF0EA3B8 /* Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B3529A1731702724B0342D /* Factory.swift */; };
 		2FA5D024DF2A429D6606350F /* KitStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D859C070F9718CACF08F /* KitStateProvider.swift */; };
+		2FA5D02628E43E329EFBDA3D /* InvalidTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5DA916AAD510ED6F15222 /* InvalidTransaction.swift */; };
 		2FA5D13C7285E79B75FAE2BE /* PeerConnectionDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5DF96100D81EACBBC87F6 /* PeerConnectionDelegateTests.swift */; };
 		2FA5D15733A45ACBD4C5B3A6 /* OutputsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5DCAE853F5F4068A34CF2 /* OutputsCache.swift */; };
 		2FA5D166F7AD6D1E7A81CB4D /* Blockchain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D05597A1DC332C67BDF7 /* Blockchain.swift */; };
@@ -325,6 +326,7 @@
 		2FA5D99586B15F4477D695F7 /* IPeerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IPeerTests.swift; sourceTree = "<group>"; };
 		2FA5D9C2AB0785426C9A8DB8 /* LockTimeSetter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockTimeSetter.swift; sourceTree = "<group>"; };
 		2FA5D9C845F4D930457A5C6F /* WatchedTransactionManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchedTransactionManagerTests.swift; sourceTree = "<group>"; };
+		2FA5DA916AAD510ED6F15222 /* InvalidTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InvalidTransaction.swift; sourceTree = "<group>"; };
 		2FA5DA9D7F78A26107F7209C /* InputSignerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputSignerTests.swift; sourceTree = "<group>"; };
 		2FA5DAAAC2F759FD42948DDE /* IPeerTaskRequesterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IPeerTaskRequesterTests.swift; sourceTree = "<group>"; };
 		2FA5DADEB0FD09138FD308A1 /* HDPrivateKeyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HDPrivateKeyTests.swift; sourceTree = "<group>"; };
@@ -667,6 +669,7 @@
 				58AAAA63CA9758D7D97E1416 /* SigHashType.swift */,
 				11B35C67DB63EF992C380513 /* Transaction.swift */,
 				11B357C9E6B02801B0422881 /* InfoObjects.swift */,
+				2FA5DA916AAD510ED6F15222 /* InvalidTransaction.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1502,6 +1505,7 @@
 				2FA5DF1AEDA8F98BB67C68ED /* ErrorStorage.swift in Sources */,
 				2FA5DDAFE800DD9C713038DB /* URLRequestConvertible.swift in Sources */,
 				2FA5D27DD695B71657E28D31 /* TransactionSendTimer.swift in Sources */,
+				2FA5D02628E43E329EFBDA3D /* InvalidTransaction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BitcoinCore/BitcoinCore.xcodeproj/project.pbxproj
+++ b/BitcoinCore/BitcoinCore.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		2FA5D2239DF0C24C4CC6366B /* PeerHostManagerDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D632A9EFB1F0CF2523DF /* PeerHostManagerDelegateTests.swift */; };
 		2FA5D24944692E30651B664A /* DustCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D3C2F5D61E0F255D6A65 /* DustCalculator.swift */; };
 		2FA5D26905936BB701998750 /* GetBlockHashesTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D65667DA8BFD91E91C8B /* GetBlockHashesTask.swift */; };
+		2FA5D27DD695B71657E28D31 /* TransactionSendTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D5C2EC52D37AC8A7E31E /* TransactionSendTimer.swift */; };
 		2FA5D2E6BA34E1A932C9C16B /* PublicKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D5A9656117A6FD41E814 /* PublicKeyManager.swift */; };
 		2FA5D371584B554068CCAD8E /* IPeerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D99586B15F4477D695F7 /* IPeerTests.swift */; };
 		2FA5D37E8B4A6D9B89410173 /* SendTransactionTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA5D2DAB8485F5F9E2E23B6 /* SendTransactionTaskTests.swift */; };
@@ -306,6 +307,7 @@
 		2FA5D570F2DD9052979281D9 /* ErrorStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorStorage.swift; sourceTree = "<group>"; };
 		2FA5D5A744085AD28EFBB868 /* Peer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Peer.swift; sourceTree = "<group>"; };
 		2FA5D5A9656117A6FD41E814 /* PublicKeyManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublicKeyManager.swift; sourceTree = "<group>"; };
+		2FA5D5C2EC52D37AC8A7E31E /* TransactionSendTimer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionSendTimer.swift; sourceTree = "<group>"; };
 		2FA5D5C9BB0E185AF72B9174 /* MerkleBlock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MerkleBlock.swift; sourceTree = "<group>"; };
 		2FA5D602DBCFC5121F7C245F /* PeerGroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeerGroupTests.swift; sourceTree = "<group>"; };
 		2FA5D632A9EFB1F0CF2523DF /* PeerHostManagerDelegateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeerHostManagerDelegateTests.swift; sourceTree = "<group>"; };
@@ -592,6 +594,7 @@
 				D096D109219E95B800E8103F /* Peer */,
 				58AAAFDF237EA32A0C25548D /* Parsers */,
 				58AAAAACEC07FF47326D89AD /* TransactionSender.swift */,
+				2FA5D5C2EC52D37AC8A7E31E /* TransactionSendTimer.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1498,6 +1501,7 @@
 				2FA5D24944692E30651B664A /* DustCalculator.swift in Sources */,
 				2FA5DF1AEDA8F98BB67C68ED /* ErrorStorage.swift in Sources */,
 				2FA5DDAFE800DD9C713038DB /* URLRequestConvertible.swift in Sources */,
+				2FA5D27DD695B71657E28D31 /* TransactionSendTimer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BitcoinCore/BitcoinCore/Core/AbstractKit.swift
+++ b/BitcoinCore/BitcoinCore/Core/AbstractKit.swift
@@ -30,8 +30,8 @@ open class AbstractKit {
         bitcoinCore.syncState
     }
 
-    open func transactions(fromHash: String? = nil, limit: Int? = nil) -> Single<[TransactionInfo]> {
-        bitcoinCore.transactions(fromHash: fromHash, limit: limit)
+    open func transactions(fromHash: String? = nil, fromTimestamp: Int? = nil, limit: Int? = nil) -> Single<[TransactionInfo]> {
+        bitcoinCore.transactions(fromHash: fromHash, fromTimestamp: fromTimestamp, limit: limit)
     }
 
     open func send(to address: String, value: Int, feeRate: Int, pluginData: [UInt8: IPluginData] = [:]) throws -> FullTransaction {

--- a/BitcoinCore/BitcoinCore/Core/BaseTransactionInfoConverter.swift
+++ b/BitcoinCore/BitcoinCore/Core/BaseTransactionInfoConverter.swift
@@ -15,7 +15,8 @@ public class BaseTransactionInfoConverter: IBaseTransactionInfoConverter {
         var fromAddresses = [TransactionAddressInfo]()
         var toAddresses = [TransactionAddressInfo]()
         var hasOnlyMyInputs = true
-        let transactionTimestamp = transactionForInfo.transactionWithBlock.transaction.timestamp
+        let transaction = transactionForInfo.transactionWithBlock.transaction
+        let transactionTimestamp = transaction.timestamp
 
         for inputWithPreviousOutput in transactionForInfo.inputsWithPreviousOutputs {
             var mine = false
@@ -55,14 +56,15 @@ public class BaseTransactionInfoConverter: IBaseTransactionInfoConverter {
         }
 
         return T(
-                transactionHash: transactionForInfo.transactionWithBlock.transaction.dataHash.reversedHex,
-                transactionIndex: transactionForInfo.transactionWithBlock.transaction.order,
+                transactionHash: transaction.dataHash.reversedHex,
+                transactionIndex: transaction.order,
                 from: fromAddresses,
                 to: toAddresses,
                 amount: amount,
                 fee: resolvedFee,
                 blockHeight: transactionForInfo.transactionWithBlock.blockHeight,
-                timestamp: transactionTimestamp
+                timestamp: transactionTimestamp,
+                status: transaction.status
         )
     }
 

--- a/BitcoinCore/BitcoinCore/Core/BitcoinCore.swift
+++ b/BitcoinCore/BitcoinCore/Core/BitcoinCore.swift
@@ -163,8 +163,8 @@ extension BitcoinCore {
         kitStateProvider.syncState
     }
 
-    public func transactions(fromHash: String? = nil, limit: Int? = nil) -> Single<[TransactionInfo]> {
-        dataProvider.transactions(fromHash: fromHash, limit: limit)
+    public func transactions(fromHash: String? = nil, fromTimestamp: Int? = nil, limit: Int? = nil) -> Single<[TransactionInfo]> {
+        dataProvider.transactions(fromHash: fromHash, fromTimestamp: fromTimestamp, limit: limit)
     }
 
     public func send(to address: String, value: Int, feeRate: Int, pluginData: [UInt8: IPluginData] = [:]) throws -> FullTransaction {

--- a/BitcoinCore/BitcoinCore/Core/BitcoinCoreBuilder.swift
+++ b/BitcoinCore/BitcoinCore/Core/BitcoinCoreBuilder.swift
@@ -173,7 +173,6 @@ public class BitcoinCoreBuilder {
         let peerManager = PeerManager()
         let unspentOutputSelector = UnspentOutputSelectorChain()
         let transactionSyncer = TransactionSyncer(storage: storage, processor: transactionProcessor, publicKeyManager: publicKeyManager)
-        let mempoolTransactions = MempoolTransactions(transactionSyncer: transactionSyncer)
 
         let blockHashFetcher = BlockHashFetcher(restoreKeyConverter: restoreKeyConverterChain, apiManager: initialSyncApi, helper: BlockHashFetcherHelper())
         let blockDiscovery = BlockDiscoveryBatch(network: network, wallet: hdWallet, blockHashFetcher: blockHashFetcher, logger: logger)
@@ -209,6 +208,7 @@ public class BitcoinCoreBuilder {
         let transactionSendTimer = TransactionSendTimer(interval: 60)
         let transactionSender = TransactionSender(transactionSyncer: transactionSyncer, syncedReadyPeerManager: syncedReadyPeerManager, storage: storage, timer: transactionSendTimer, logger: logger)
         let transactionCreator = TransactionCreator(transactionBuilder: transactionBuilder, transactionProcessor: transactionProcessor, transactionSender: transactionSender, bloomFilterManager: bloomFilterManager)
+        let mempoolTransactions = MempoolTransactions(transactionSyncer: transactionSyncer, transactionSender: transactionSender)
 
         let syncManager = SyncManager(reachabilityManager: reachabilityManager, initialSyncer: initialSyncer, peerGroup: peerGroup)
 

--- a/BitcoinCore/BitcoinCore/Core/BitcoinCoreBuilder.swift
+++ b/BitcoinCore/BitcoinCore/Core/BitcoinCoreBuilder.swift
@@ -161,7 +161,7 @@ public class BitcoinCoreBuilder {
         let transactionProcessor = TransactionProcessor(storage: storage,
                 outputExtractor: transactionOutputExtractor, inputExtractor: transactionInputExtractor,
                 outputsCache: myOutputsCache, outputAddressExtractor: transactionAddressExtractor,
-                addressManager: publicKeyManager, irregularOutputFinder: irregularOutputFinder, listener: dataProvider)
+                addressManager: publicKeyManager, irregularOutputFinder: irregularOutputFinder, transactionInfoConverter: transactionInfoConverter, listener: dataProvider)
 
         let kitStateProvider = KitStateProvider()
 

--- a/BitcoinCore/BitcoinCore/Core/DataProvider.swift
+++ b/BitcoinCore/BitcoinCore/Core/DataProvider.swift
@@ -94,7 +94,7 @@ extension DataProvider: IDataProvider {
                 resolvedOrder = transaction.order
             }
 
-            let transactions = self.storage.fullTransactionsInfo(fromTimestamp: resolvedTimestamp, fromOrder: resolvedOrder, limit: limit)
+            let transactions = self.storage.validOrInvalidTransactionsFullInfo(fromTimestamp: resolvedTimestamp, fromOrder: resolvedOrder, limit: limit)
 
             observer(.success(transactions.map() { self.transactionInfoConverter.transactionInfo(fromTransaction: $0) }))
             return Disposables.create()

--- a/BitcoinCore/BitcoinCore/Core/Protocols.swift
+++ b/BitcoinCore/BitcoinCore/Core/Protocols.swift
@@ -128,6 +128,7 @@ public protocol IStorage {
     func add(publicKeys: [PublicKey])
     func publicKeysWithUsedState() -> [PublicKeyWithUsedState]
     func publicKey(byPath: String) -> PublicKey?
+    func invalidate(transaction: Transaction, transactionInfo: TransactionInfo) throws
 }
 
 public protocol IRestoreKeyConverter {
@@ -312,11 +313,11 @@ protocol IOutputsCache: class {
 }
 
 public protocol ITransactionProcessor: class {
-    func processInvalid(transactionWithHash: Data)
     var listener: IBlockchainDataListener? { get set }
 
     func processReceived(transactions: [FullTransaction], inBlock block: Block?, skipCheckBloomFilter: Bool) throws
     func processCreated(transaction: FullTransaction) throws
+    func processInvalid(transactionHash: Data)
 }
 
 protocol ITransactionExtractor {
@@ -338,7 +339,7 @@ protocol ITransactionPublicKeySetter {
 public protocol ITransactionSyncer: class {
     func newTransactions() -> [FullTransaction]
     func handleRelayed(transactions: [FullTransaction])
-    func handleInvalid(transactionWithHash: Data)
+    func handleInvalid(fullTransaction: FullTransaction)
     func shouldRequestTransaction(hash: Data) -> Bool
 }
 
@@ -481,11 +482,11 @@ public protocol IMerkleBranch: class {
 }
 
 public extension INetwork {
-    var protocolVersion: Int32 { return 70015 }
+    var protocolVersion: Int32 { 70015 }
 
-    var maxBlockSize: UInt32 { return 1_000_000 }
-    var serviceFullNode: UInt64 { return 1 }
-    var bloomFilter: Int32 { return 70000 }
+    var maxBlockSize: UInt32 { 1_000_000 }
+    var serviceFullNode: UInt64 { 1 }
+    var bloomFilter: Int32 { 70000 }
 
 }
 
@@ -586,7 +587,7 @@ public protocol IPlugin {
     func processTransactionWithNullData(transaction: FullTransaction, nullDataChunks: inout IndexingIterator<[Chunk]>) throws
     func isSpendable(unspentOutput: UnspentOutput) throws -> Bool
     func inputSequenceNumber(output: Output) throws -> Int
-    func parsePluginData(from: Output, transactionTimestamp: Int) throws -> IPluginOutputData
+    func parsePluginData(from: String, transactionTimestamp: Int) throws -> IPluginOutputData
     func keysForApiRestore(publicKey: PublicKey) throws -> [String]
 }
 
@@ -598,7 +599,7 @@ public protocol IPluginManager {
     func processInputs(mutableTransaction: MutableTransaction) throws
     func processTransactionWithNullData(transaction: FullTransaction, nullDataOutput: Output) throws
     func isSpendable(unspentOutput: UnspentOutput) -> Bool
-    func parsePluginData(from: Output, transactionTimestamp: Int) -> [UInt8: IPluginOutputData]?
+    func parsePluginData(fromPlugin: UInt8, pluginDataString: String, transactionTimestamp: Int) -> IPluginOutputData?
 }
 
 public protocol IBlockMedianTimeHelper {

--- a/BitcoinCore/BitcoinCore/Core/Protocols.swift
+++ b/BitcoinCore/BitcoinCore/Core/Protocols.swift
@@ -539,6 +539,7 @@ public protocol IPeerTaskHandler: class {
 protocol ITransactionSender {
     func verifyCanSend() throws
     func send(pendingTransaction: FullTransaction) throws
+    func markTransactionsSent(transactions: [FullTransaction])
 }
 
 protocol ITransactionSendTimerDelegate: class {

--- a/BitcoinCore/BitcoinCore/Core/Protocols.swift
+++ b/BitcoinCore/BitcoinCore/Core/Protocols.swift
@@ -312,6 +312,7 @@ protocol IOutputsCache: class {
 }
 
 public protocol ITransactionProcessor: class {
+    func processInvalid(transactionWithHash: Data)
     var listener: IBlockchainDataListener? { get set }
 
     func processReceived(transactions: [FullTransaction], inBlock block: Block?, skipCheckBloomFilter: Bool) throws

--- a/BitcoinCore/BitcoinCore/Core/Protocols.swift
+++ b/BitcoinCore/BitcoinCore/Core/Protocols.swift
@@ -119,6 +119,7 @@ public protocol IStorage {
 
     func sentTransaction(byHash: Data) -> SentTransaction?
     func update(sentTransaction: SentTransaction)
+    func delete(sentTransaction: SentTransaction)
     func add(sentTransaction: SentTransaction)
 
     func publicKeys() -> [PublicKey]
@@ -334,9 +335,9 @@ protocol ITransactionPublicKeySetter {
 }
 
 public protocol ITransactionSyncer: class {
-    func pendingTransactions() -> [FullTransaction]
-    func handle(transactions: [FullTransaction])
-    func handle(sentTransaction transaction: FullTransaction)
+    func newTransactions() -> [FullTransaction]
+    func handleRelayed(transactions: [FullTransaction])
+    func handleInvalid(transactionHash: Data)
     func shouldRequestTransaction(hash: Data) -> Bool
 }
 
@@ -424,7 +425,7 @@ protocol IKitStateProviderDelegate: class {
 }
 
 public protocol ITransactionInfo: class {
-    init(transactionHash: String, transactionIndex: Int, from: [TransactionAddressInfo], to: [TransactionAddressInfo], amount: Int, fee: Int?, blockHeight: Int?, timestamp: Int)
+    init(transactionHash: String, transactionIndex: Int, from: [TransactionAddressInfo], to: [TransactionAddressInfo], amount: Int, fee: Int?, blockHeight: Int?, timestamp: Int, status: TransactionStatus)
 }
 
 public protocol ITransactionInfoConverter {
@@ -523,7 +524,7 @@ public protocol IInitialBlockDownload {
 
 public protocol ISyncedReadyPeerManager {
     var peers: [IPeer] { get }
-    var observable: Observable<IPeer> { get }
+    var observable: Observable<Void> { get }
 }
 
 public protocol IInventoryItemsHandler: class {
@@ -537,6 +538,16 @@ public protocol IPeerTaskHandler: class {
 protocol ITransactionSender {
     func verifyCanSend() throws
     func send(pendingTransaction: FullTransaction) throws
+}
+
+protocol ITransactionSendTimerDelegate: class {
+    func timePassed()
+}
+
+protocol ITransactionSendTimer {
+    var delegate: ITransactionSendTimerDelegate? { get set }
+    func startIfNotRunning()
+    func stop()
 }
 
 protocol IMerkleBlockHandler: AnyObject {

--- a/BitcoinCore/BitcoinCore/Core/Protocols.swift
+++ b/BitcoinCore/BitcoinCore/Core/Protocols.swift
@@ -338,7 +338,7 @@ protocol ITransactionPublicKeySetter {
 public protocol ITransactionSyncer: class {
     func newTransactions() -> [FullTransaction]
     func handleRelayed(transactions: [FullTransaction])
-    func handleInvalid(transactionHash: Data)
+    func handleInvalid(transactionWithHash: Data)
     func shouldRequestTransaction(hash: Data) -> Bool
 }
 
@@ -539,7 +539,7 @@ public protocol IPeerTaskHandler: class {
 protocol ITransactionSender {
     func verifyCanSend() throws
     func send(pendingTransaction: FullTransaction) throws
-    func markTransactionsSent(transactions: [FullTransaction])
+    func transactionsRelayed(transactions: [FullTransaction])
 }
 
 protocol ITransactionSendTimerDelegate: class {

--- a/BitcoinCore/BitcoinCore/Core/Protocols.swift
+++ b/BitcoinCore/BitcoinCore/Core/Protocols.swift
@@ -101,6 +101,7 @@ public protocol IStorage {
 
     func transactionExists(byHash: Data) -> Bool
     func transaction(byHash: Data) -> Transaction?
+    func validOrInvalidTransaction(byHash: Data, timestamp: Int) -> Transaction?
     func transactions(ofBlock: Block) -> [Transaction]
     func newTransactions() -> [Transaction]
     func newTransaction(byHash: Data) -> Transaction?
@@ -442,7 +443,7 @@ protocol IDataProvider {
     var lastBlockInfo: BlockInfo? { get }
     var balance: BalanceInfo { get }
     func debugInfo(network: INetwork, scriptType: ScriptType, addressConverter: IAddressConverter) -> String
-    func transactions(fromHash: String?, limit: Int?) -> Single<[TransactionInfo]>
+    func transactions(fromHash: String?, fromTimestamp: Int?, limit: Int?) -> Single<[TransactionInfo]>
 }
 
 protocol IDataProviderDelegate: class {

--- a/BitcoinCore/BitcoinCore/Core/Protocols.swift
+++ b/BitcoinCore/BitcoinCore/Core/Protocols.swift
@@ -110,12 +110,14 @@ public protocol IStorage {
     func fullInfo(forTransactions: [TransactionWithBlock]) -> [FullTransactionForInfo]
     func fullTransactionsInfo(fromTimestamp: Int?, fromOrder: Int?, limit: Int?) -> [FullTransactionForInfo]
     func fullTransactionInfo(byHash hash: Data) -> FullTransactionForInfo?
+    func moveTransactionsTo(invalidTransactions: [InvalidTransaction]) throws
 
     func outputsWithPublicKeys() -> [OutputWithPublicKey]
     func unspentOutputs() -> [UnspentOutput]
     func inputs(transactionHash: Data) -> [Input]
     func outputs(transactionHash: Data) -> [Output]
     func previousOutput(ofInput: Input) -> Output?
+    func inputsUsingOutputs(withTransactionHash: Data) -> [Input]
 
     func sentTransaction(byHash: Data) -> SentTransaction?
     func update(sentTransaction: SentTransaction)
@@ -128,7 +130,6 @@ public protocol IStorage {
     func add(publicKeys: [PublicKey])
     func publicKeysWithUsedState() -> [PublicKeyWithUsedState]
     func publicKey(byPath: String) -> PublicKey?
-    func invalidate(transaction: Transaction, transactionInfo: TransactionInfo) throws
 }
 
 public protocol IRestoreKeyConverter {

--- a/BitcoinCore/BitcoinCore/Core/Protocols.swift
+++ b/BitcoinCore/BitcoinCore/Core/Protocols.swift
@@ -109,8 +109,8 @@ public protocol IStorage {
     func add(transaction: FullTransaction) throws
     func update(transaction: Transaction) throws
     func fullInfo(forTransactions: [TransactionWithBlock]) -> [FullTransactionForInfo]
-    func fullTransactionsInfo(fromTimestamp: Int?, fromOrder: Int?, limit: Int?) -> [FullTransactionForInfo]
-    func fullTransactionInfo(byHash hash: Data) -> FullTransactionForInfo?
+    func validOrInvalidTransactionsFullInfo(fromTimestamp: Int?, fromOrder: Int?, limit: Int?) -> [FullTransactionForInfo]
+    func transactionFullInfo(byHash hash: Data) -> FullTransactionForInfo?
     func moveTransactionsTo(invalidTransactions: [InvalidTransaction]) throws
 
     func outputsWithPublicKeys() -> [OutputWithPublicKey]

--- a/BitcoinCore/BitcoinCore/Managers/InitialSync/SyncTransactionItem.swift
+++ b/BitcoinCore/BitcoinCore/Managers/InitialSync/SyncTransactionItem.swift
@@ -26,9 +26,9 @@ open class SyncTransactionItem: ImmutableMappable {
 
 open class SyncTransactionOutputItem: ImmutableMappable {
     public let script: String
-    public let address: String
+    public let address: String?
 
-    public init(script: String, address: String) {
+    public init(script: String, address: String?) {
         self.script = script
         self.address = address
     }

--- a/BitcoinCore/BitcoinCore/Managers/PluginManager.swift
+++ b/BitcoinCore/BitcoinCore/Managers/PluginManager.swift
@@ -28,7 +28,7 @@ extension PluginManager: IPluginManager {
     }
 
     func maxSpendLimit(pluginData: [UInt8: IPluginData]) throws -> Int? {
-        try pluginData.flatMap({ key, data in
+        try pluginData.compactMap({ key, data in
             guard let plugin = plugins[key] else {
                 throw PluginError.pluginNotFound
             }

--- a/BitcoinCore/BitcoinCore/Managers/PluginManager.swift
+++ b/BitcoinCore/BitcoinCore/Managers/PluginManager.swift
@@ -100,13 +100,12 @@ extension PluginManager: IPluginManager {
         return (try? plugin.isSpendable(unspentOutput: unspentOutput)) ?? true
     }
 
-    public func parsePluginData(from output: Output, transactionTimestamp: Int) -> [UInt8: IPluginOutputData]? {
-        guard let pluginId = output.pluginId, let plugin = plugins[pluginId],
-              let parsedData = try? plugin.parsePluginData(from: output, transactionTimestamp: transactionTimestamp) else {
+    public func parsePluginData(fromPlugin pluginId: UInt8, pluginDataString: String, transactionTimestamp: Int) -> IPluginOutputData? {
+        guard let plugin = plugins[pluginId] else {
             return nil
         }
 
-        return [plugin.id: parsedData]
+        return try? plugin.parsePluginData(from: pluginDataString, transactionTimestamp: transactionTimestamp)
     }
 
 }

--- a/BitcoinCore/BitcoinCore/Models/InfoObjects.swift
+++ b/BitcoinCore/BitcoinCore/Models/InfoObjects.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-open class TransactionInfo: ITransactionInfo {
+open class TransactionInfo: ITransactionInfo, Codable {
     public let transactionHash: String
     public let transactionIndex: Int
     public let from: [TransactionAddressInfo]
@@ -26,10 +26,23 @@ open class TransactionInfo: ITransactionInfo {
 
 }
 
-public struct TransactionAddressInfo {
+public class TransactionAddressInfo: Codable {
     public let address: String
     public let mine: Bool
-    public let pluginData: [UInt8: IPluginOutputData]?
+    public var pluginId: UInt8? = nil
+    public var pluginData: IPluginOutputData? = nil
+
+    var pluginDataString: String? = nil
+
+    private enum CodingKeys: String, CodingKey {
+        case address, mine, pluginId, pluginDataString
+    }
+
+    public init(address: String, mine: Bool) {
+        self.address = address
+        self.mine = mine
+    }
+
 }
 
 public struct BlockInfo {

--- a/BitcoinCore/BitcoinCore/Models/InfoObjects.swift
+++ b/BitcoinCore/BitcoinCore/Models/InfoObjects.swift
@@ -9,8 +9,10 @@ open class TransactionInfo: ITransactionInfo {
     public let fee: Int?
     public let blockHeight: Int?
     public let timestamp: Int
+    public let status: TransactionStatus
 
-    public required init(transactionHash: String, transactionIndex: Int, from: [TransactionAddressInfo], to: [TransactionAddressInfo], amount: Int, fee: Int?, blockHeight: Int?, timestamp: Int) {
+    public required init(transactionHash: String, transactionIndex: Int, from: [TransactionAddressInfo], to: [TransactionAddressInfo], amount: Int, fee: Int?, blockHeight: Int?,
+                         timestamp: Int, status: TransactionStatus) {
         self.transactionHash = transactionHash
         self.transactionIndex = transactionIndex
         self.from = from
@@ -19,6 +21,7 @@ open class TransactionInfo: ITransactionInfo {
         self.fee = fee
         self.blockHeight = blockHeight
         self.timestamp = timestamp
+        self.status = status
     }
 
 }

--- a/BitcoinCore/BitcoinCore/Models/InvalidTransaction.swift
+++ b/BitcoinCore/BitcoinCore/Models/InvalidTransaction.swift
@@ -1,0 +1,46 @@
+import Foundation
+import HSCryptoKit
+import GRDB
+
+class InvalidTransaction: Transaction {
+
+    let transactionInfoJson: Data
+
+    init(dataHash: Data, version: Int, lockTime: Int, timestamp: Int, order: Int, blockHash: Data?, isMine: Bool, isOutgoing: Bool, status: TransactionStatus, segWit: Bool, transactionInfoJson: Data) {
+        self.transactionInfoJson = transactionInfoJson
+
+        super.init()
+
+        self.dataHash = dataHash
+        self.version = version
+        self.lockTime = lockTime
+        self.timestamp = timestamp
+        self.order = order
+        self.blockHash = blockHash
+        self.isMine = isMine
+        self.isOutgoing = isOutgoing
+        self.status = status
+        self.segWit = segWit
+    }
+
+
+    override open class var databaseTableName: String {
+        "invalid_transactions"
+    }
+
+    enum Columns: String, ColumnExpression, CaseIterable {
+        case transactionInfoJson
+    }
+
+    required init(row: Row) {
+        transactionInfoJson = row[Columns.transactionInfoJson]
+
+        super.init(row: row)
+    }
+
+    override open func encode(to container: inout PersistenceContainer) {
+        super.encode(to: &container)
+        container[Columns.transactionInfoJson] = transactionInfoJson
+    }
+
+}

--- a/BitcoinCore/BitcoinCore/Models/InvalidTransaction.swift
+++ b/BitcoinCore/BitcoinCore/Models/InvalidTransaction.swift
@@ -2,7 +2,7 @@ import Foundation
 import HSCryptoKit
 import GRDB
 
-class InvalidTransaction: Transaction {
+public class InvalidTransaction: Transaction {
 
     let transactionInfoJson: Data
 

--- a/BitcoinCore/BitcoinCore/Models/SentTransaction.swift
+++ b/BitcoinCore/BitcoinCore/Models/SentTransaction.swift
@@ -2,14 +2,12 @@ import GRDB
 
 public class SentTransaction: Record {
     let dataHash: Data
-    var firstSendTime: Double
     var lastSendTime: Double
     var retriesCount: Int
     var sendSuccess: Bool
 
-    init(dataHash: Data, firstSendTime: Double, lastSendTime: Double, retriesCount: Int, sendSuccess: Bool) {
+    init(dataHash: Data, lastSendTime: Double, retriesCount: Int, sendSuccess: Bool) {
         self.dataHash = dataHash
-        self.firstSendTime = firstSendTime
         self.lastSendTime = lastSendTime
         self.retriesCount = retriesCount
         self.sendSuccess = sendSuccess
@@ -22,12 +20,11 @@ public class SentTransaction: Record {
     }
 
     convenience init(dataHash: Data) {
-        self.init(dataHash: dataHash, firstSendTime: CACurrentMediaTime(), lastSendTime: CACurrentMediaTime(), retriesCount: 0, sendSuccess: false)
+        self.init(dataHash: dataHash, lastSendTime: CACurrentMediaTime(), retriesCount: 0, sendSuccess: false)
     }
 
     enum Columns: String, ColumnExpression {
         case dataHash
-        case firstSendTime
         case lastSendTime
         case retriesCount
         case sendSuccess
@@ -35,7 +32,6 @@ public class SentTransaction: Record {
 
     required init(row: Row) {
         dataHash = row[Columns.dataHash]
-        firstSendTime = row[Columns.firstSendTime]
         lastSendTime = row[Columns.lastSendTime]
         retriesCount = row[Columns.retriesCount]
         sendSuccess = row[Columns.sendSuccess]
@@ -45,7 +41,6 @@ public class SentTransaction: Record {
 
     override open func encode(to container: inout PersistenceContainer) {
         container[Columns.dataHash] = dataHash
-        container[Columns.firstSendTime] = firstSendTime
         container[Columns.lastSendTime] = lastSendTime
         container[Columns.retriesCount] = retriesCount
         container[Columns.sendSuccess] = sendSuccess

--- a/BitcoinCore/BitcoinCore/Models/SentTransaction.swift
+++ b/BitcoinCore/BitcoinCore/Models/SentTransaction.swift
@@ -5,22 +5,24 @@ public class SentTransaction: Record {
     var firstSendTime: Double
     var lastSendTime: Double
     var retriesCount: Int
+    var sendSuccess: Bool
 
-    init(dataHash: Data, firstSendTime: Double, lastSendTime: Double, retriesCount: Int) {
+    init(dataHash: Data, firstSendTime: Double, lastSendTime: Double, retriesCount: Int, sendSuccess: Bool) {
         self.dataHash = dataHash
         self.firstSendTime = firstSendTime
         self.lastSendTime = lastSendTime
         self.retriesCount = retriesCount
+        self.sendSuccess = sendSuccess
 
         super.init()
     }
 
     override open class var databaseTableName: String {
-        return "sentTransactions"
+        "sentTransactions"
     }
 
     convenience init(dataHash: Data) {
-        self.init(dataHash: dataHash, firstSendTime: CACurrentMediaTime(), lastSendTime: CACurrentMediaTime(), retriesCount: 0)
+        self.init(dataHash: dataHash, firstSendTime: CACurrentMediaTime(), lastSendTime: CACurrentMediaTime(), retriesCount: 0, sendSuccess: false)
     }
 
     enum Columns: String, ColumnExpression {
@@ -28,6 +30,7 @@ public class SentTransaction: Record {
         case firstSendTime
         case lastSendTime
         case retriesCount
+        case sendSuccess
     }
 
     required init(row: Row) {
@@ -35,6 +38,7 @@ public class SentTransaction: Record {
         firstSendTime = row[Columns.firstSendTime]
         lastSendTime = row[Columns.lastSendTime]
         retriesCount = row[Columns.retriesCount]
+        sendSuccess = row[Columns.sendSuccess]
 
         super.init(row: row)
     }
@@ -44,6 +48,7 @@ public class SentTransaction: Record {
         container[Columns.firstSendTime] = firstSendTime
         container[Columns.lastSendTime] = lastSendTime
         container[Columns.retriesCount] = retriesCount
+        container[Columns.sendSuccess] = sendSuccess
     }
 
 }

--- a/BitcoinCore/BitcoinCore/Models/Transaction.swift
+++ b/BitcoinCore/BitcoinCore/Models/Transaction.swift
@@ -2,7 +2,7 @@ import Foundation
 import HSCryptoKit
 import GRDB
 
-public enum TransactionStatus: Int, DatabaseValueConvertible { case new, relayed, invalid }
+public enum TransactionStatus: Int, DatabaseValueConvertible, Codable { case new, relayed, invalid }
 
 public class Transaction: Record {
     public var dataHash: Data
@@ -28,7 +28,7 @@ public class Transaction: Record {
 
 
     override open class var databaseTableName: String {
-        return "transactions"
+        "transactions"
     }
 
     enum Columns: String, ColumnExpression, CaseIterable {

--- a/BitcoinCore/BitcoinCore/Network/Peer/MempoolTransactions.swift
+++ b/BitcoinCore/BitcoinCore/Network/Peer/MempoolTransactions.swift
@@ -56,7 +56,7 @@ extension MempoolTransactions : IPeerTaskHandler {
         case let task as RequestTransactionsTask:
             transactionSyncer.handleRelayed(transactions: task.transactions)
             removeFromRequestedTransactions(peerHost: peer.host, transactionHashes: task.transactions.map { $0.header.dataHash })
-            transactionSender.markTransactionsSent(transactions: task.transactions)
+            transactionSender.transactionsRelayed(transactions: task.transactions)
             return true
 
         default: return false

--- a/BitcoinCore/BitcoinCore/Network/Peer/MempoolTransactions.swift
+++ b/BitcoinCore/BitcoinCore/Network/Peer/MempoolTransactions.swift
@@ -3,10 +3,12 @@ import RxSwift
 class MempoolTransactions {
     private let disposeBag = DisposeBag()
     private let transactionSyncer: ITransactionSyncer
+    private let transactionSender: ITransactionSender
     private var requestedTransactions = [String: [Data]]()
 
-    init(transactionSyncer: ITransactionSyncer) {
+    init(transactionSyncer: ITransactionSyncer, transactionSender: ITransactionSender) {
         self.transactionSyncer = transactionSyncer
+        self.transactionSender = transactionSender
     }
 
     private func addToRequestTransactions(peerHost: String, transactionHashes: [Data]) {
@@ -54,6 +56,7 @@ extension MempoolTransactions : IPeerTaskHandler {
         case let task as RequestTransactionsTask:
             transactionSyncer.handleRelayed(transactions: task.transactions)
             removeFromRequestedTransactions(peerHost: peer.host, transactionHashes: task.transactions.map { $0.header.dataHash })
+            transactionSender.markTransactionsSent(transactions: task.transactions)
             return true
 
         default: return false

--- a/BitcoinCore/BitcoinCore/Network/Peer/MempoolTransactions.swift
+++ b/BitcoinCore/BitcoinCore/Network/Peer/MempoolTransactions.swift
@@ -52,12 +52,8 @@ extension MempoolTransactions : IPeerTaskHandler {
     func handleCompletedTask(peer: IPeer, task: PeerTask) -> Bool {
         switch task {
         case let task as RequestTransactionsTask:
-            transactionSyncer.handle(transactions: task.transactions)
+            transactionSyncer.handleRelayed(transactions: task.transactions)
             removeFromRequestedTransactions(peerHost: peer.host, transactionHashes: task.transactions.map { $0.header.dataHash })
-            return true
-
-        case let task as SendTransactionTask:
-            transactionSyncer.handle(sentTransaction: task.transaction)
             return true
 
         default: return false
@@ -65,6 +61,7 @@ extension MempoolTransactions : IPeerTaskHandler {
     }
 
 }
+
 extension MempoolTransactions : IInventoryItemsHandler {
 
     func handleInventoryItems(peer: IPeer, inventoryItems: [InventoryItem]) {

--- a/BitcoinCore/BitcoinCore/Network/Peer/PeerTask/GetBlockHashesTask.swift
+++ b/BitcoinCore/BitcoinCore/Network/Peer/PeerTask/GetBlockHashesTask.swift
@@ -43,7 +43,8 @@ class GetBlockHashesTask: PeerTask {
         if let requester = requester {
             requester.send(message: GetBlocksMessage(protocolVersion: requester.protocolVersion, headerHashes: blockLocatorHashes))
         }
-        resetTimer()
+
+        super.start()
     }
 
     override func handle(message: IMessage) throws -> Bool {

--- a/BitcoinCore/BitcoinCore/Network/Peer/PeerTask/GetMerkleBlocksTask.swift
+++ b/BitcoinCore/BitcoinCore/Network/Peer/PeerTask/GetMerkleBlocksTask.swift
@@ -52,7 +52,8 @@ class GetMerkleBlocksTask: PeerTask {
 
         requester?.send(message: GetDataMessage(inventoryItems: items))
         resumeWaiting()
-        resetTimer()
+
+        super.start()
     }
 
     override func handle(message: IMessage) throws -> Bool {

--- a/BitcoinCore/BitcoinCore/Network/Peer/PeerTask/PeerTask.swift
+++ b/BitcoinCore/BitcoinCore/Network/Peer/PeerTask/PeerTask.swift
@@ -17,10 +17,11 @@ open class PeerTask {
     open var state: String { "" }
 
     open func start() {
+        resetTimer()
     }
 
     open func handle(message: IMessage) throws -> Bool {
-        return false
+        false
     }
 
     open func checkTimeout() {

--- a/BitcoinCore/BitcoinCore/Network/Peer/PeerTask/RequestTransactionsTask.swift
+++ b/BitcoinCore/BitcoinCore/Network/Peer/PeerTask/RequestTransactionsTask.swift
@@ -19,6 +19,8 @@ class RequestTransactionsTask: PeerTask {
         }
 
         requester?.send(message: GetDataMessage(inventoryItems: items))
+
+        super.start()
     }
 
     override func handle(message: IMessage) throws -> Bool {

--- a/BitcoinCore/BitcoinCore/Network/TransactionSendTimer.swift
+++ b/BitcoinCore/BitcoinCore/Network/TransactionSendTimer.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+class TransactionSendTimer {
+    let interval: TimeInterval
+
+    weak var delegate: ITransactionSendTimerDelegate?
+    var runLoop: RunLoop?
+    var timer: Timer?
+
+    init(interval: TimeInterval) {
+        self.interval = interval
+    }
+
+}
+
+extension TransactionSendTimer: ITransactionSendTimer {
+
+    func startIfNotRunning() {
+        guard runLoop == nil else {
+            return
+        }
+
+        DispatchQueue.global(qos: .background).async {
+            self.runLoop = .current
+
+            let timer = Timer(timeInterval: self.interval, repeats: true, block: { [weak self] _ in self?.delegate?.timePassed() })
+            self.timer = timer
+
+            RunLoop.current.add(timer, forMode: .common)
+            RunLoop.current.run()
+        }
+    }
+
+    func stop() {
+        if let runLoop = self.runLoop {
+            timer?.invalidate()
+            timer?.invalidate()
+
+            CFRunLoopStop(runLoop.getCFRunLoop())
+            timer = nil
+            self.runLoop = nil
+        }
+    }
+
+}

--- a/BitcoinCore/BitcoinCore/Network/TransactionSender.swift
+++ b/BitcoinCore/BitcoinCore/Network/TransactionSender.swift
@@ -46,7 +46,7 @@ class TransactionSender {
     private func transactionsToSend(from transactions: [FullTransaction]) -> [FullTransaction] {
         transactions.filter { transaction in
             if let sentTransaction = storage.sentTransaction(byHash: transaction.header.dataHash) {
-                return sentTransaction.retriesCount < self.maxRetriesCount && sentTransaction.lastSendTime < CACurrentMediaTime() - self.retriesPeriod
+                return sentTransaction.lastSendTime < CACurrentMediaTime() - self.retriesPeriod
             } else {
                 return true
             }
@@ -63,7 +63,7 @@ class TransactionSender {
         sentTransaction.sendSuccess = true
 
         if sentTransaction.retriesCount >= maxRetriesCount {
-            transactionSyncer.handleInvalid(transactionWithHash: transaction.header.dataHash)
+            transactionSyncer.handleInvalid(fullTransaction: transaction)
             storage.delete(sentTransaction: sentTransaction)
         } else {
             storage.update(sentTransaction: sentTransaction)

--- a/BitcoinCore/BitcoinCore/Network/TransactionSender.swift
+++ b/BitcoinCore/BitcoinCore/Network/TransactionSender.swift
@@ -16,7 +16,7 @@ class TransactionSender {
 
     init(transactionSyncer: ITransactionSyncer, syncedReadyPeerManager: ISyncedReadyPeerManager, storage: IStorage, timer: ITransactionSendTimer,
          logger: Logger? = nil, queue: DispatchQueue = DispatchQueue(label: "Transaction Sender Queue", qos: .background),
-         maxRetriesCount: Int = 2, retriesPeriod: Double = 60, totalRetriesPeriod: Double = 60 * 60 * 24) {
+         maxRetriesCount: Int = 3, retriesPeriod: Double = 60, totalRetriesPeriod: Double = 60 * 60 * 24) {
         self.transactionSyncer = transactionSyncer
         self.syncedReadyPeerManager = syncedReadyPeerManager
         self.storage = storage

--- a/BitcoinCore/BitcoinCore/Network/TransactionSender.swift
+++ b/BitcoinCore/BitcoinCore/Network/TransactionSender.swift
@@ -68,7 +68,6 @@ class TransactionSender {
 
         if sentTransaction.retriesCount >= maxRetriesCount { // Also check for totalRetriesPeriod
             transactionSyncer.handleInvalid(transactionHash: transaction.header.dataHash)
-            // Also remove SentTransaction on successful send
             storage.delete(sentTransaction: sentTransaction)
         } else {
             storage.update(sentTransaction: sentTransaction)
@@ -131,6 +130,14 @@ extension TransactionSender: ITransactionSender {
 
         queue.async {
             self.send(transactions: [pendingTransaction], toPeers: peers)
+        }
+    }
+
+    func markTransactionsSent(transactions: [FullTransaction]) {
+        for transaction in transactions {
+            if let sentTransaction = storage.sentTransaction(byHash: transaction.header.dataHash) {
+                storage.delete(sentTransaction: sentTransaction)
+            }
         }
     }
 

--- a/BitcoinCore/BitcoinCore/Storage/GrdbStorage.swift
+++ b/BitcoinCore/BitcoinCore/Storage/GrdbStorage.swift
@@ -171,6 +171,12 @@ open class GrdbStorage {
             }
         }
 
+        migrator.registerMigration("addSendSuccessToSentTransaction") { db in
+            try db.alter(table: SentTransaction.databaseTableName) { t in
+                t.add(column: SentTransaction.Columns.sendSuccess.name, .boolean)
+            }
+        }
+
         return migrator
     }
 
@@ -723,6 +729,12 @@ extension GrdbStorage: IStorage {
     public func update(sentTransaction: SentTransaction) {
         _ = try! dbPool.write { db in
             try sentTransaction.update(db)
+        }
+    }
+
+    public func delete(sentTransaction: SentTransaction) {
+        _ = try! dbPool.write { db in
+            try sentTransaction.delete(db)
         }
     }
 

--- a/BitcoinCore/BitcoinCore/Storage/GrdbStorage.swift
+++ b/BitcoinCore/BitcoinCore/Storage/GrdbStorage.swift
@@ -680,7 +680,7 @@ extension GrdbStorage: IStorage {
                       INNER JOIN publicKeys ON outputs.publicKeyPath = publicKeys.path
                       INNER JOIN transactions ON outputs.transactionHash = transactions.dataHash
                       LEFT JOIN blocks ON transactions.blockHash = blocks.headerHash
-                      WHERE outputs.scriptType != \(ScriptType.unknown.rawValue)
+                      WHERE transactions.status != \(TransactionStatus.invalid.rawValue) AND outputs.scriptType != \(ScriptType.unknown.rawValue)
                       """
             let rows = try Row.fetchCursor(db, sql: sql, adapter: adapter)
 

--- a/BitcoinCore/BitcoinCore/Storage/GrdbStorage.swift
+++ b/BitcoinCore/BitcoinCore/Storage/GrdbStorage.swift
@@ -45,7 +45,6 @@ open class GrdbStorage {
         migrator.registerMigration("createSentTransactions") { db in
             try db.create(table: SentTransaction.databaseTableName) { t in
                 t.column(SentTransaction.Columns.dataHash.name, .text).notNull()
-                t.column(SentTransaction.Columns.firstSendTime.name, .double).notNull()
                 t.column(SentTransaction.Columns.lastSendTime.name, .double).notNull()
                 t.column(SentTransaction.Columns.retriesCount.name, .integer).notNull()
 

--- a/BitcoinCore/BitcoinCore/Storage/GrdbStorage.swift
+++ b/BitcoinCore/BitcoinCore/Storage/GrdbStorage.swift
@@ -597,7 +597,7 @@ extension GrdbStorage: IStorage {
         return results
     }
 
-    public func fullTransactionInfo(byHash hash: Data) -> FullTransactionForInfo? {
+    public func transactionFullInfo(byHash hash: Data) -> FullTransactionForInfo? {
         var transaction: TransactionWithBlock? = nil
 
         try! dbPool.read { db in
@@ -609,7 +609,7 @@ extension GrdbStorage: IStorage {
 
             let sql = """
                       SELECT transactions.*, blocks.height as blockHeight
-                      FROM (SELECT transactions.*, x'' AS transactionInfoJson FROM transactions UNION ALL SELECT * FROM invalid_transactions) AS transactions
+                      FROM transactions
                       LEFT JOIN blocks ON transactions.blockHash = blocks.headerHash
                       WHERE transactions.dataHash = \("x'" + hash.hex + "'")                    
                       """
@@ -628,7 +628,7 @@ extension GrdbStorage: IStorage {
         return fullInfo(forTransactions: [transactionWithBlock]).first
     }
 
-    public func fullTransactionsInfo(fromTimestamp: Int?, fromOrder: Int?, limit: Int?) -> [FullTransactionForInfo] {
+    public func validOrInvalidTransactionsFullInfo(fromTimestamp: Int?, fromOrder: Int?, limit: Int?) -> [FullTransactionForInfo] {
         var transactions = [TransactionWithBlock]()
 
         try! dbPool.read { db in

--- a/BitcoinCore/BitcoinCore/Transactions/TransactionProcessor.swift
+++ b/BitcoinCore/BitcoinCore/Transactions/TransactionProcessor.swift
@@ -119,4 +119,14 @@ extension TransactionProcessor: ITransactionProcessor {
         }
     }
 
+    public func processInvalid(transactionWithHash hash: Data) {
+        guard let transaction = storage.transaction(byHash: hash) else {
+            return
+        }
+
+        transaction.status = .invalid
+        try? storage.update(transaction: transaction)
+        listener?.onUpdate(updated: [transaction], inserted: [], inBlock: nil)
+    }
+
 }

--- a/BitcoinCore/BitcoinCore/Transactions/TransactionProcessor.swift
+++ b/BitcoinCore/BitcoinCore/Transactions/TransactionProcessor.swift
@@ -152,7 +152,7 @@ extension TransactionProcessor: ITransactionProcessor {
     }
 
     private func descendantTransactionsFullInfo(of transactionHash: Data) -> [FullTransactionForInfo] {
-        guard let fullTransactionInfo = storage.fullTransactionInfo(byHash: transactionHash) else {
+        guard let fullTransactionInfo = storage.transactionFullInfo(byHash: transactionHash) else {
             return []
         }
 

--- a/BitcoinCore/BitcoinCore/Transactions/TransactionSyncer.swift
+++ b/BitcoinCore/BitcoinCore/Transactions/TransactionSyncer.swift
@@ -4,53 +4,28 @@ public class TransactionSyncer {
     private let storage: IStorage
     private let transactionProcessor: ITransactionProcessor
     private let publicKeyManager: IPublicKeyManager
-    private let maxRetriesCount: Int
-    private let retriesPeriod: Double // seconds
-    private let totalRetriesPeriod: Double // seconds
 
-    init(storage: IStorage, processor: ITransactionProcessor, publicKeyManager: IPublicKeyManager,
-         maxRetriesCount: Int = 3, retriesPeriod: Double = 60, totalRetriesPeriod: Double = 60 * 60 * 24) {
+    init(storage: IStorage, processor: ITransactionProcessor, publicKeyManager: IPublicKeyManager) {
         self.storage = storage
         self.transactionProcessor = processor
         self.publicKeyManager = publicKeyManager
-        self.maxRetriesCount = maxRetriesCount
-        self.retriesPeriod = retriesPeriod
-        self.totalRetriesPeriod = totalRetriesPeriod
     }
 
 }
 
 extension TransactionSyncer: ITransactionSyncer {
 
-    public func pendingTransactions() -> [FullTransaction] {
-        return storage.newTransactions()
-                .filter { transaction in
-                    if let sentTransaction = storage.sentTransaction(byHash: transaction.dataHash) {
-                        return sentTransaction.retriesCount < self.maxRetriesCount &&
-                                sentTransaction.lastSendTime < CACurrentMediaTime() - self.retriesPeriod &&
-                                sentTransaction.firstSendTime > CACurrentMediaTime() - self.totalRetriesPeriod
-                    } else {
-                        return true
-                    }
-                }
-                .map { FullTransaction(header: $0, inputs: self.storage.inputs(transactionHash: $0.dataHash), outputs: self.storage.outputs(transactionHash: $0.dataHash)) }
-    }
-
-    public func handle(sentTransaction transaction: FullTransaction) {
-        guard let transaction = storage.newTransaction(byHash: transaction.header.dataHash) else {
-            return
-        }
-
-        if let sentTransaction = storage.sentTransaction(byHash: transaction.dataHash) {
-            sentTransaction.lastSendTime = CACurrentMediaTime()
-            sentTransaction.retriesCount = sentTransaction.retriesCount + 1
-            storage.update(sentTransaction: sentTransaction)
-        } else {
-            storage.add(sentTransaction: SentTransaction(dataHash: transaction.dataHash))
+    public func newTransactions() -> [FullTransaction] {
+        storage.newTransactions().map {
+            FullTransaction(
+                    header: $0,
+                    inputs: self.storage.inputs(transactionHash: $0.dataHash),
+                    outputs: self.storage.outputs(transactionHash: $0.dataHash)
+            )
         }
     }
 
-    public func handle(transactions: [FullTransaction]) {
+    public func handleRelayed(transactions: [FullTransaction]) {
         guard !transactions.isEmpty else {
             return
         }
@@ -69,8 +44,15 @@ extension TransactionSyncer: ITransactionSyncer {
         }
     }
 
+    public func handleInvalid(transactionHash: Data) {
+        if let transaction = storage.transaction(byHash: transactionHash) {
+            transaction.status = .invalid
+            try? storage.update(transaction: transaction)
+        }
+    }
+
     public func shouldRequestTransaction(hash: Data) -> Bool {
-        return !storage.relayedTransactionExists(byHash: hash)
+        !storage.relayedTransactionExists(byHash: hash)
     }
 
 }

--- a/BitcoinCore/BitcoinCore/Transactions/TransactionSyncer.swift
+++ b/BitcoinCore/BitcoinCore/Transactions/TransactionSyncer.swift
@@ -44,8 +44,8 @@ extension TransactionSyncer: ITransactionSyncer {
         }
     }
 
-    public func handleInvalid(transactionWithHash hash: Data) {
-        transactionProcessor.processInvalid(transactionWithHash: hash)
+    public func handleInvalid(fullTransaction: FullTransaction) {
+        transactionProcessor.processInvalid(transactionHash: fullTransaction.header.dataHash)
     }
 
     public func shouldRequestTransaction(hash: Data) -> Bool {

--- a/BitcoinCore/BitcoinCore/Transactions/TransactionSyncer.swift
+++ b/BitcoinCore/BitcoinCore/Transactions/TransactionSyncer.swift
@@ -44,8 +44,8 @@ extension TransactionSyncer: ITransactionSyncer {
         }
     }
 
-    public func handleInvalid(transactionHash: Data) {
-        transactionProcessor.processInvalid(transactionWithHash: transactionHash)
+    public func handleInvalid(transactionWithHash hash: Data) {
+        transactionProcessor.processInvalid(transactionWithHash: hash)
     }
 
     public func shouldRequestTransaction(hash: Data) -> Bool {

--- a/BitcoinCore/BitcoinCore/Transactions/TransactionSyncer.swift
+++ b/BitcoinCore/BitcoinCore/Transactions/TransactionSyncer.swift
@@ -45,10 +45,7 @@ extension TransactionSyncer: ITransactionSyncer {
     }
 
     public func handleInvalid(transactionHash: Data) {
-        if let transaction = storage.transaction(byHash: transactionHash) {
-            transaction.status = .invalid
-            try? storage.update(transaction: transaction)
-        }
+        transactionProcessor.processInvalid(transactionWithHash: transactionHash)
     }
 
     public func shouldRequestTransaction(hash: Data) -> Bool {

--- a/BitcoinCore/BitcoinCoreTests/Transactions/TransactionProcessorTests.swift
+++ b/BitcoinCore/BitcoinCoreTests/Transactions/TransactionProcessorTests.swift
@@ -12,6 +12,7 @@ class TransactionProcessorTests: XCTestCase {
     private var mockBlockchainDataListener: MockIBlockchainDataListener!
     private var mockTransactionListener: MockITransactionListener!
     private var mockIrregularOutputFinder: MockIIrregularOutputFinder!
+    private var mockTransactionInfoConverter: MockITransactionInfoConverter!
 
     private var generatedDate: Date!
     private var dateGenerator: (() -> Date)!
@@ -35,6 +36,7 @@ class TransactionProcessorTests: XCTestCase {
         mockBlockchainDataListener = MockIBlockchainDataListener()
         mockTransactionListener = MockITransactionListener()
         mockIrregularOutputFinder = MockIIrregularOutputFinder()
+        mockTransactionInfoConverter = MockITransactionInfoConverter()
 
         stub(mockStorage) { mock in
             when(mock.transaction(byHash: any())).thenReturn(nil)
@@ -73,7 +75,7 @@ class TransactionProcessorTests: XCTestCase {
         transactionProcessor = TransactionProcessor(
                 storage: mockStorage, outputExtractor: mockOutputExtractor, inputExtractor: mockInputExtractor, outputsCache: mockOutputsCache,
                 outputAddressExtractor: mockOutputAddressExtractor, addressManager: mockAddressManager, irregularOutputFinder: mockIrregularOutputFinder,
-                listener: mockBlockchainDataListener, dateGenerator: dateGenerator
+                transactionInfoConverter: mockTransactionInfoConverter, listener: mockBlockchainDataListener, dateGenerator: dateGenerator
         )
         transactionProcessor.transactionListener = mockTransactionListener
     }

--- a/BitcoinCore/BitcoinCoreTests/Transactions/TransactionSyncerTests.swift
+++ b/BitcoinCore/BitcoinCoreTests/Transactions/TransactionSyncerTests.swift
@@ -104,13 +104,14 @@ class TransactionSyncerTests: QuickSpec {
 
         describe("#handleInvalid(transactionWithHash:)") {
             it("calls processes invalid transaction") {
-                let hash = Data(repeating: 0, count: 32)
+                let fullTransaction = TestData.p2pkhTransaction
+
                 stub(mockTransactionProcessor) { mock in
-                    when(mock.processInvalid(transactionWithHash: equal(to: hash))).thenDoNothing()
+                    when(mock.processInvalid(transactionHash: equal(to: fullTransaction.header.dataHash))).thenDoNothing()
                 }
 
-                syncer.handleInvalid(transactionWithHash: hash)
-                verify(mockTransactionProcessor).processInvalid(transactionWithHash: equal(to: hash))
+                syncer.handleInvalid(fullTransaction: fullTransaction)
+                verify(mockTransactionProcessor).processInvalid(transactionHash: equal(to: fullTransaction.header.dataHash))
             }
         }
 

--- a/BitcoinKit.swift.podspec
+++ b/BitcoinKit.swift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'BitcoinKit.swift'
   spec.module_name = 'BitcoinKit'
-  spec.version = '0.9.0'
+  spec.version = '0.10.0'
   spec.summary = 'Bitcoin library for Swift'
   spec.description = <<-DESC
                        BitcoinKit implements Bitcoin protocol in Swift.
@@ -18,8 +18,8 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = '11.0'
   spec.swift_version = '5'
 
-  spec.dependency 'BitcoinCore.swift', '~> 0.9.0'
-  spec.dependency 'Hodler.swift', '~> 0.9.0'
+  spec.dependency 'BitcoinCore.swift', '~> 0.10.0'
+  spec.dependency 'Hodler.swift', '~> 0.10.0'
   spec.dependency 'HSCryptoKit', '~> 1.4'
   spec.dependency 'HSHDWalletKit', '~> 1.2'
   spec.dependency 'Alamofire', '~> 4.0'

--- a/BitcoinKit/BitcoinKit/Core/BitcoinKit.swift
+++ b/BitcoinKit/BitcoinKit/Core/BitcoinKit.swift
@@ -33,7 +33,7 @@ public class BitcoinKit: AbstractKit {
         }
         let initialSyncApi = BCoinApi(url: initialSyncApiUrl)
 
-        let databaseFilePath = try DirectoryHelper.directoryURL(for: BitcoinKit.name).appendingPathComponent(BitcoinKit.databaseFileName(walletId: walletId, networkType: networkType)).path
+        let databaseFilePath = try DirectoryHelper.directoryURL(for: BitcoinKit.name).appendingPathComponent(BitcoinKit.databaseFileName(walletId: walletId, networkType: networkType, bip: bip, syncMode: syncMode)).path
         let storage = GrdbStorage(databaseFilePath: databaseFilePath)
 
         let paymentAddressParser = PaymentAddressParser(validScheme: "bitcoin", removeScheme: true)
@@ -88,19 +88,11 @@ public class BitcoinKit: AbstractKit {
 extension BitcoinKit {
 
     public static func clear(exceptFor walletIdsToExclude: [String] = []) throws {
-        var excludedFileNames = [String]()
-
-        for walletId in walletIdsToExclude {
-            for type in NetworkType.allCases {
-                excludedFileNames.append(databaseFileName(walletId: walletId, networkType: type))
-            }
-        }
-
-        try DirectoryHelper.removeAll(inDirectory: BitcoinKit.name, except: excludedFileNames)
+        try DirectoryHelper.removeAll(inDirectory: BitcoinKit.name, except: walletIdsToExclude)
     }
 
-    private static func databaseFileName(walletId: String, networkType: NetworkType) -> String {
-        "\(walletId)-\(networkType.rawValue)"
+    private static func databaseFileName(walletId: String, networkType: NetworkType, bip: Bip, syncMode: BitcoinCore.SyncMode) -> String {
+        "\(walletId)-\(networkType.rawValue)-\(bip.description)-\(syncMode)"
     }
 
 }

--- a/DashKit.swift.podspec
+++ b/DashKit.swift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'DashKit.swift'
   spec.module_name = 'DashKit'
-  spec.version = '0.9.0'
+  spec.version = '0.10.0'
   spec.summary = 'Dash library for Swift'
   spec.description = <<-DESC
                        DashKit implements Dash protocol in Swift.
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = '11.0'
   spec.swift_version = '5'
 
-  spec.dependency 'BitcoinCore.swift', '~> 0.9.0'
+  spec.dependency 'BitcoinCore.swift', '~> 0.10.0'
   spec.dependency 'HSCryptoKit', '~> 1.4'
   spec.dependency 'HSHDWalletKit', '~> 1.2'
   spec.dependency 'CryptoBLS.swift', '~> 1.1'

--- a/DashKit/DashKit/Core/DashKit.swift
+++ b/DashKit/DashKit/Core/DashKit.swift
@@ -148,8 +148,8 @@ public class DashKit: AbstractKit {
         try super.send(to: address, value: value, feeRate: feeRate)
     }
 
-    public func transactions(fromHash: String?, limit: Int?) -> Single<[DashTransactionInfo]> {
-        super.transactions(fromHash: fromHash, limit: limit).map { self.cast(transactionInfos: $0) }
+    public func transactions(fromHash: String?, fromTimestamp: Int?, limit: Int?) -> Single<[DashTransactionInfo]> {
+        super.transactions(fromHash: fromHash, fromTimestamp: fromTimestamp, limit: limit).map { self.cast(transactionInfos: $0) }
     }
 
 }

--- a/DashKit/DashKit/Core/DashKit.swift
+++ b/DashKit/DashKit/Core/DashKit.swift
@@ -184,7 +184,7 @@ extension DashKit: BitcoinCoreDelegate {
 extension DashKit: IInstantTransactionDelegate {
 
     public func onUpdateInstant(transactionHash: Data) {
-        guard let transaction = storage.fullTransactionInfo(byHash: transactionHash) else {
+        guard let transaction = storage.transactionFullInfo(byHash: transactionHash) else {
             return
         }
         let transactionInfo = dashTransactionInfoConverter.transactionInfo(fromTransaction: transaction)

--- a/DashKit/DashKit/Core/DashKit.swift
+++ b/DashKit/DashKit/Core/DashKit.swift
@@ -36,7 +36,7 @@ public class DashKit: AbstractKit {
 
         let logger = Logger(network: network, minLogLevel: minLogLevel)
 
-        let databaseFilePath = try DirectoryHelper.directoryURL(for: DashKit.name).appendingPathComponent(DashKit.databaseFileName(walletId: walletId, networkType: networkType)).path
+        let databaseFilePath = try DirectoryHelper.directoryURL(for: DashKit.name).appendingPathComponent(DashKit.databaseFileName(walletId: walletId, networkType: networkType, syncMode: syncMode)).path
         let storage = DashGrdbStorage(databaseFilePath: databaseFilePath)
         self.storage = storage
 
@@ -200,19 +200,11 @@ extension DashKit: IInstantTransactionDelegate {
 extension DashKit {
 
     public static func clear(exceptFor walletIdsToExclude: [String] = []) throws {
-        var excludedFileNames = [String]()
-
-        for walletId in walletIdsToExclude {
-            for type in NetworkType.allCases {
-                excludedFileNames.append(databaseFileName(walletId: walletId, networkType: type))
-            }
-        }
-
-        try DirectoryHelper.removeAll(inDirectory: DashKit.name, except: excludedFileNames)
+        try DirectoryHelper.removeAll(inDirectory: DashKit.name, except: walletIdsToExclude)
     }
 
-    private static func databaseFileName(walletId: String, networkType: NetworkType) -> String {
-        "\(walletId)-\(networkType.rawValue)"
+    private static func databaseFileName(walletId: String, networkType: NetworkType, syncMode: BitcoinCore.SyncMode) -> String {
+        "\(walletId)-\(networkType.rawValue)-\(syncMode)"
     }
 
 }

--- a/DashKit/DashKit/Core/Protocols.swift
+++ b/DashKit/DashKit/Core/Protocols.swift
@@ -24,7 +24,7 @@ protocol IDashTransactionSizeCalculator {
 }
 
 protocol IDashTransactionSyncer {
-    func handle(transactions: [FullTransaction])
+    func handleRelayed(transactions: [FullTransaction])
 }
 
 protocol IDashPeer: IPeer {

--- a/DashKit/DashKit/Core/Protocols.swift
+++ b/DashKit/DashKit/Core/Protocols.swift
@@ -95,7 +95,7 @@ protocol IDashStorage {
     func unspentOutputs() -> [UnspentOutput]
 
     func transactionExists(byHash: Data) -> Bool
-    func fullTransactionInfo(byHash hash: Data) -> FullTransactionForInfo?
+    func transactionFullInfo(byHash hash: Data) -> FullTransactionForInfo?
 }
 
 protocol IInstantSendFactory {

--- a/DashKit/DashKit/InstantSend/InstantSend.swift
+++ b/DashKit/DashKit/InstantSend/InstantSend.swift
@@ -53,7 +53,7 @@ extension InstantSend: IPeerTaskHandler {
     }
 
     private func handle(transactions: [FullTransaction]) {
-        transactionSyncer.handle(transactions: transactions)
+        transactionSyncer.handleRelayed(transactions: transactions)
 
         for transaction in transactions {
             transactionLockVoteHandler.handle(transaction: transaction)

--- a/DashKit/DashKit/InstantSend/InstantTransactionSyncer.swift
+++ b/DashKit/DashKit/InstantSend/InstantTransactionSyncer.swift
@@ -7,8 +7,8 @@ class InstantTransactionSyncer: IDashTransactionSyncer {
         self.transactionSyncer = transactionSyncer
     }
 
-    func handle(transactions: [FullTransaction]) {
-        transactionSyncer.handle(transactions: transactions)
+    func handleRelayed(transactions: [FullTransaction]) {
+        transactionSyncer.handleRelayed(transactions: transactions)
     }
 
 }

--- a/DashKit/DashKit/Models/DashTransactionInfo.swift
+++ b/DashKit/DashKit/Models/DashTransactionInfo.swift
@@ -3,8 +3,26 @@ import BitcoinCore
 public class DashTransactionInfo: TransactionInfo {
     public var instantTx: Bool = false
 
+    private enum CodingKeys: String, CodingKey {
+        case instantTx
+    }
+
     public required init(transactionHash: String, transactionIndex: Int, from: [TransactionAddressInfo], to: [TransactionAddressInfo], amount: Int, fee: Int?, blockHeight: Int?, timestamp: Int, status: TransactionStatus) {
         super.init(transactionHash: transactionHash, transactionIndex: transactionIndex, from: from, to: to, amount: amount, fee: fee, blockHeight: blockHeight, timestamp: timestamp, status: status)
+    }
+
+    public required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        instantTx = try container.decode(Bool.self, forKey: .instantTx)
+    }
+
+    override public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(instantTx, forKey: .instantTx)
+
+        try super.encode(to: encoder)
     }
 
 }

--- a/DashKit/DashKit/Models/DashTransactionInfo.swift
+++ b/DashKit/DashKit/Models/DashTransactionInfo.swift
@@ -3,8 +3,8 @@ import BitcoinCore
 public class DashTransactionInfo: TransactionInfo {
     public var instantTx: Bool = false
 
-    public required init(transactionHash: String, transactionIndex: Int, from: [TransactionAddressInfo], to: [TransactionAddressInfo], amount: Int, fee: Int?, blockHeight: Int?, timestamp: Int) {
-        super.init(transactionHash: transactionHash, transactionIndex: transactionIndex, from: from, to: to, amount: amount, fee: fee, blockHeight: blockHeight, timestamp: timestamp)
+    public required init(transactionHash: String, transactionIndex: Int, from: [TransactionAddressInfo], to: [TransactionAddressInfo], amount: Int, fee: Int?, blockHeight: Int?, timestamp: Int, status: TransactionStatus) {
+        super.init(transactionHash: transactionHash, transactionIndex: transactionIndex, from: from, to: to, amount: amount, fee: fee, blockHeight: blockHeight, timestamp: timestamp, status: status)
     }
 
 }

--- a/DashKit/DashKit/Network/Peer/PeerTask/RequestLlmqInstantLocksTask.swift
+++ b/DashKit/DashKit/Network/Peer/PeerTask/RequestLlmqInstantLocksTask.swift
@@ -14,7 +14,8 @@ class RequestLlmqInstantLocksTask: PeerTask {
     override func start() {
         let items = hashes.map { hash in InventoryItem(type: DashInventoryType.msgIsLock.rawValue, hash: hash) }
         requester?.send(message: GetDataMessage(inventoryItems: items))
-        resetTimer()
+
+        super.start()
     }
 
     override func handle(message: IMessage) -> Bool {

--- a/DashKit/DashKit/Network/Peer/PeerTask/RequestMasternodeListDiffTask.swift
+++ b/DashKit/DashKit/Network/Peer/PeerTask/RequestMasternodeListDiffTask.swift
@@ -15,6 +15,8 @@ class RequestMasternodeListDiffTask: PeerTask {
         let message = GetMasternodeListDiffMessage(baseBlockHash: baseBlockHash, blockHash: blockHash)
 
         requester?.send(message: message)
+
+        super.start()
     }
 
     override func handle(message: IMessage) -> Bool {

--- a/DashKit/DashKit/Network/Peer/PeerTask/RequestTransactionLockRequestsTask.swift
+++ b/DashKit/DashKit/Network/Peer/PeerTask/RequestTransactionLockRequestsTask.swift
@@ -14,7 +14,8 @@ class RequestTransactionLockRequestsTask: PeerTask {
     override func start() {
         let items = hashes.map { hash in InventoryItem(type: DashInventoryType.msgTxLockRequest.rawValue, hash: hash) }
         requester?.send(message: GetDataMessage(inventoryItems: items))
-        resetTimer()
+
+        super.start()
     }
 
     override func handle(message: IMessage) -> Bool {

--- a/DashKit/DashKit/Network/Peer/PeerTask/RequestTransactionLockVotesTask.swift
+++ b/DashKit/DashKit/Network/Peer/PeerTask/RequestTransactionLockVotesTask.swift
@@ -14,7 +14,8 @@ class RequestTransactionLockVotesTask: PeerTask {
     override func start() {
         let items = hashes.map { hash in InventoryItem(type: DashInventoryType.msgTxLockVote.rawValue, hash: hash) }
         requester?.send(message: GetDataMessage(inventoryItems: items))
-        resetTimer()
+
+        super.start()
     }
 
     override func handle(message: IMessage) -> Bool {

--- a/Demo/Demo/Adapters/BaseAdapter.swift
+++ b/Demo/Demo/Adapters/BaseAdapter.swift
@@ -23,11 +23,11 @@ class BaseAdapter {
 
     func transactionRecord(fromTransaction transaction: TransactionInfo) -> TransactionRecord {
         let fromAddresses = transaction.from.map {
-            TransactionAddress(address: $0.address, mine: $0.mine, pluginData: $0.pluginData)
+            TransactionAddress(address: $0.address, mine: $0.mine, pluginId: $0.pluginId, pluginData: $0.pluginData)
         }
 
         let toAddresses = transaction.to.map {
-            TransactionAddress(address: $0.address, mine: $0.mine, pluginData: $0.pluginData)
+            TransactionAddress(address: $0.address, mine: $0.mine, pluginId: $0.pluginId, pluginData: $0.pluginData)
         }
 
         return TransactionRecord(

--- a/Demo/Demo/Adapters/BaseAdapter.swift
+++ b/Demo/Demo/Adapters/BaseAdapter.swift
@@ -32,6 +32,7 @@ class BaseAdapter {
 
         return TransactionRecord(
                 transactionHash: transaction.transactionHash,
+                status: TransactionStatus(rawValue: transaction.status.rawValue) ?? TransactionStatus.new,
                 transactionIndex: transaction.transactionIndex,
                 amount: Decimal(transaction.amount) / coinRate,
                 fee: transaction.fee.map { Decimal($0) / coinRate },

--- a/Demo/Demo/Adapters/BaseAdapter.swift
+++ b/Demo/Demo/Adapters/BaseAdapter.swift
@@ -51,10 +51,10 @@ class BaseAdapter {
         return NSDecimalNumber(decimal: coinValue).rounding(accordingToBehavior: handler).intValue
     }
 
-    func transactionsSingle(fromHash: String?, limit: Int) -> Single<[TransactionRecord]> {
-        abstractKit.transactions(fromHash: fromHash, limit: limit)
+    func transactionsSingle(fromHash: String?, fromTimestamp: Int?, limit: Int) -> Single<[TransactionRecord]> {
+        abstractKit.transactions(fromHash: fromHash, fromTimestamp: fromTimestamp, limit: limit)
                 .map { [weak self] transactions -> [TransactionRecord] in
-                    return transactions.compactMap {
+                    transactions.compactMap {
                         self?.transactionRecord(fromTransaction: $0)
                     }
                 }

--- a/Demo/Demo/Adapters/DashAdapter.swift
+++ b/Demo/Demo/Adapters/DashAdapter.swift
@@ -15,10 +15,10 @@ class DashAdapter: BaseAdapter {
         dashKit.delegate = self
     }
 
-    override func transactionsSingle(fromHash: String?, limit: Int) -> Single<[TransactionRecord]> {
-        return dashKit.transactions(fromHash: fromHash, limit: limit)
+    override func transactionsSingle(fromHash: String?, fromTimestamp: Int?, limit: Int) -> Single<[TransactionRecord]> {
+        dashKit.transactions(fromHash: fromHash, fromTimestamp: fromTimestamp, limit: limit)
                 .map { [weak self] transactions -> [TransactionRecord] in
-                    return transactions.compactMap {
+                    transactions.compactMap {
                         self?.transactionRecord(fromTransaction: $0)
                     }
                 }

--- a/Demo/Demo/Controllers/BalanceController.swift
+++ b/Demo/Demo/Controllers/BalanceController.swift
@@ -59,7 +59,7 @@ class BalanceController: UITableViewController {
 
     @objc func start() {
         Manager.shared.adapters.forEach { $0.start() }
-        if let button = navigationItem.rightBarButtonItem as? UIBarButtonItem {
+        if let button = navigationItem.rightBarButtonItem {
             button.title = "Refresh"
             button.action = #selector(refresh)
         }

--- a/Demo/Demo/Controllers/Cells/TransactionCell.swift
+++ b/Demo/Demo/Controllers/Cells/TransactionCell.swift
@@ -43,6 +43,7 @@ class TransactionCell: UITableViewCell {
 
         set(string: """
                     Tx Hash:
+                    Tx Status:
                     Tx Index:
                     Date:
                     Amount:
@@ -55,6 +56,7 @@ class TransactionCell: UITableViewCell {
 
         set(string: """
                     \(format(hash: transaction.transactionHash))
+                    \(transaction.status)
                     \(transaction.transactionIndex)
                     \(TransactionCell.dateFormatter.string(from: Date(timeIntervalSince1970: transaction.timestamp)))
                     \(transaction.amount) \(coinCode)
@@ -104,7 +106,7 @@ extension TransactionCell {
 
     static func rowHeight(for transaction: TransactionRecord) -> Int {
         let addressRowsCount = transaction.to.reduce(0) { $0 + rowsCount(address: $1) } + transaction.from.count
-        var height = (addressRowsCount + 7) * 20 + 10
+        var height = (addressRowsCount + 7) * 22 + 10
 
         if transaction.transactionExtraType != nil {
             height += 20

--- a/Demo/Demo/Controllers/Cells/TransactionCell.swift
+++ b/Demo/Demo/Controllers/Cells/TransactionCell.swift
@@ -34,7 +34,7 @@ class TransactionCell: UITableViewCell {
             if to.mine {
                 string += " (mine)"
             }
-            if let pluginData = to.pluginData, let hodlerPluginData = pluginData[HodlerPlugin.id], let hodlerData = hodlerPluginData as? HodlerOutputData {
+            if let pluginId = to.pluginId, let pluginData = to.pluginData, pluginId == HodlerPlugin.id, let hodlerData = pluginData as? HodlerOutputData {
                 string += "\nLocked Until: \(TransactionCell.dateFormatter.string(from: Date(timeIntervalSince1970: Double(hodlerData.approximateUnlockTime!))))  <-"
                 string += "\nOriginal: \(format(hash: hodlerData.addressString))  <-"
             }
@@ -97,7 +97,7 @@ extension TransactionCell {
     static func rowsCount(address: TransactionAddress) -> Int {
         var rowsCount = 1
 
-        if let pluginData = address.pluginData, let hodlerData = pluginData[HodlerPlugin.id], let _ = hodlerData as? HodlerOutputData {
+        if let pluginId = address.pluginId, pluginId == HodlerPlugin.id {
             rowsCount += 2
         }
         

--- a/Demo/Demo/Controllers/ReceiveController.swift
+++ b/Demo/Demo/Controllers/ReceiveController.swift
@@ -53,7 +53,6 @@ class ReceiveController: UIViewController {
 
     @objc func onSegmentChanged() {
         updateAddress()
-        print("segment changed")
 
         currentAdapter?.printDebugs()
     }

--- a/Demo/Demo/Controllers/TransactionsController.swift
+++ b/Demo/Demo/Controllers/TransactionsController.swift
@@ -128,8 +128,9 @@ class TransactionsController: UITableViewController {
         loading = true
 
         let fromHash = transactions.last?.transactionHash
+        let fromTimestamp = transactions.last.flatMap { Int($0.timestamp) }
 
-        currentAdapter?.transactionsSingle(fromHash: fromHash, limit: limit)
+        currentAdapter?.transactionsSingle(fromHash: fromHash, fromTimestamp: fromTimestamp, limit: limit)
                 .subscribeOn(ConcurrentDispatchQueueScheduler(qos: .background))
                 .observeOn(MainScheduler.instance)
                 .subscribe(onSuccess: { [weak self] transactions in

--- a/Demo/Demo/Core/TransactionRecord.swift
+++ b/Demo/Demo/Core/TransactionRecord.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct TransactionRecord {
     let transactionHash: String
+    let status: TransactionStatus
     let transactionIndex: Int
 
     let amount: Decimal
@@ -20,4 +21,8 @@ struct TransactionAddress {
     let address: String
     let mine: Bool
     let pluginData: [UInt8: Any]?
+}
+
+enum TransactionStatus: Int {
+    case new, relayed, invalid
 }

--- a/Demo/Demo/Core/TransactionRecord.swift
+++ b/Demo/Demo/Core/TransactionRecord.swift
@@ -20,7 +20,8 @@ struct TransactionRecord {
 struct TransactionAddress {
     let address: String
     let mine: Bool
-    let pluginData: [UInt8: Any]?
+    let pluginId: UInt8?
+    let pluginData: Any?
 }
 
 enum TransactionStatus: Int {

--- a/Hodler/Hodler/Core/HodlerOutputData.swift
+++ b/Hodler/Hodler/Core/HodlerOutputData.swift
@@ -3,6 +3,7 @@ import BitcoinCore
 public class HodlerOutputData: IPluginOutputData {
     public let lockTimeInterval: HodlerPlugin.LockTimeInterval
     public let addressString: String
+    public let lockedValue: Int
     public var approximateUnlockTime: Int? = nil
 
     static func parse(serialized: String?) throws -> HodlerOutputData {
@@ -12,28 +13,31 @@ public class HodlerOutputData: IPluginOutputData {
 
         let parts = serialized.split(separator: "|")
 
-        guard parts.count == 2 else {
+        guard parts.count == 3 else {
             throw HodlerPluginError.invalidData
         }
 
         let lockTimeIntervalStr = String(parts[0])
         let addressString = String(parts[1])
+        let lockedValueString = String(parts[2])
 
-        guard let int16 = UInt16(lockTimeIntervalStr), let lockTimeInterval = HodlerPlugin.LockTimeInterval(rawValue: int16) else {
+        guard let int16 = UInt16(lockTimeIntervalStr), let lockTimeInterval = HodlerPlugin.LockTimeInterval(rawValue: int16),
+              let lockedValue = Int(lockedValueString) else {
             throw HodlerPluginError.invalidData
         }
 
 
-        return HodlerOutputData(lockTimeInterval: lockTimeInterval, addressString: addressString)
+        return HodlerOutputData(lockTimeInterval: lockTimeInterval, addressString: addressString, lockedValue: lockedValue)
     }
 
-    init(lockTimeInterval: HodlerPlugin.LockTimeInterval, addressString: String) {
+    init(lockTimeInterval: HodlerPlugin.LockTimeInterval, addressString: String, lockedValue: Int) {
         self.lockTimeInterval = lockTimeInterval
         self.addressString = addressString
+        self.lockedValue = lockedValue
     }
 
     func toString() -> String {
-        "\(lockTimeInterval.rawValue)|\(addressString)"
+        "\(lockTimeInterval.rawValue)|\(addressString)|\(lockedValue)"
     }
 
 }

--- a/Hodler/Hodler/Core/HolderPlugin.swift
+++ b/Hodler/Hodler/Core/HolderPlugin.swift
@@ -11,7 +11,7 @@ public enum HodlerPluginError: Error {
 public class HodlerPlugin {
     public static let lockedValueLimit = 50_000_000 // 0.5 BTC
 
-    public enum LockTimeInterval: UInt16, CaseIterable {
+    public enum LockTimeInterval: UInt16, CaseIterable, Codable {
         case hour = 7           //  60 * 60 / 512
         case month = 5063       //  30 * 24 * 60 * 60 / 512
         case halfYear = 30881   // 183 * 24 * 60 * 60 / 512
@@ -147,8 +147,8 @@ extension HodlerPlugin: IPlugin {
         Int((try lockTimeIntervalFrom(output: output)).sequenceNumber)
     }
 
-    public func parsePluginData(from output: Output, transactionTimestamp: Int) throws -> IPluginOutputData {
-        let hodlerOutputData = try HodlerOutputData.parse(serialized: output.pluginData)
+    public func parsePluginData(from pluginData: String, transactionTimestamp: Int) throws -> IPluginOutputData {
+        let hodlerOutputData = try HodlerOutputData.parse(serialized: pluginData)
 
         // When checking if UTXO is spendable we use the best block median time.
         // The median time is 6 blocks earlier which is approximately equal to 1 hour.

--- a/Hodler/Hodler/Core/HolderPlugin.swift
+++ b/Hodler/Hodler/Core/HolderPlugin.swift
@@ -125,7 +125,8 @@ extension HodlerPlugin: IPlugin {
         output.pluginId = id
         output.pluginData = HodlerOutputData(
                 lockTimeInterval: lockTimeInterval,
-                addressString: (try addressConverter.convert(keyHash: publicKeyHash, type: .p2pkh).stringValue)
+                addressString: (try addressConverter.convert(keyHash: publicKeyHash, type: .p2pkh).stringValue),
+                lockedValue: output.value
         ).toString()
 
         if let publicKey = publicKeyStorage.publicKey(byRawOrKeyHash: publicKeyHash) {


### PR DESCRIPTION
- Transactions are marked invalid after 3 send attempts. An attempt to send transactions is counted if SendTransaction task is completed (either by sending "tx" message in response to "getdata" message, or by timeout of 30 seconds). If SendTransaction task was not created or there was some immediate error that failed that task, then transaction send attempt is not counted.
- Invalid transactions are stored in separate "invalid_transactions" table and joined with main "transactions" table when getting the list of transactions
- For pagination timestamp of transaction is needed, since now there may be invalid transactions with the same hashes


closes #451 