### PR TITLE
Fix bug with dust validation

### DIFF
--- a/BitcoinCashKit/Classes/Network/MainNet.swift
+++ b/BitcoinCashKit/Classes/Network/MainNet.swift
@@ -21,5 +21,5 @@ class MainNet: INetwork {
         "seed-abc.bitcoinforks.org",
     ]
 
-    let dustRelayTxFee = 1000    // https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/src/policy/policy.h#L78
+    let dustRelayTxFee = 3000
 }

--- a/BitcoinCore/Classes/Core/BitcoinCoreBuilder.swift
+++ b/BitcoinCore/Classes/Core/BitcoinCoreBuilder.swift
@@ -269,8 +269,8 @@ public class BitcoinCoreBuilder {
         peerGroup.inventoryItemsHandler = bitcoinCore.inventoryItemsHandlerChain
 
         bitcoinCore.prepend(addressConverter: Base58AddressConverter(addressVersion: network.pubKeyHash, addressScriptVersion: network.scriptHash))
-        bitcoinCore.prepend(unspentOutputSelector: UnspentOutputSelector(calculator: transactionSizeCalculator, provider: unspentOutputProvider))
-        bitcoinCore.prepend(unspentOutputSelector: UnspentOutputSelectorSingleNoChange(calculator: transactionSizeCalculator, provider: unspentOutputProvider))
+        bitcoinCore.prepend(unspentOutputSelector: UnspentOutputSelector(calculator: transactionSizeCalculator, provider: unspentOutputProvider, dustCalculator: dustCalculator))
+        bitcoinCore.prepend(unspentOutputSelector: UnspentOutputSelectorSingleNoChange(calculator: transactionSizeCalculator, provider: unspentOutputProvider, dustCalculator: dustCalculator))
         // this part can be moved to another place
 
         let blockHeaderParser = BlockHeaderParser(hasher: blockHeaderHasher ?? doubleShaHasher)

--- a/BitcoinCore/Classes/Core/Protocols.swift
+++ b/BitcoinCore/Classes/Core/Protocols.swift
@@ -413,12 +413,12 @@ public protocol ITransactionSizeCalculator {
     func toBytes(fee: Int) -> Int
 }
 
-protocol IDustCalculator {
+public protocol IDustCalculator {
     func dust(type: ScriptType) -> Int
 }
 
 public protocol IUnspentOutputSelector {
-    func select(value: Int, feeRate: Int, outputScriptType: ScriptType, changeType: ScriptType, senderPay: Bool, dust: Int, pluginDataOutputSize: Int) throws -> SelectedUnspentOutputInfo
+    func select(value: Int, feeRate: Int, outputScriptType: ScriptType, changeType: ScriptType, senderPay: Bool, pluginDataOutputSize: Int) throws -> SelectedUnspentOutputInfo
 }
 
 public protocol IUnspentOutputProvider {

--- a/BitcoinCore/Classes/Helpers/UnspentOutputSelectorChain.swift
+++ b/BitcoinCore/Classes/Helpers/UnspentOutputSelectorChain.swift
@@ -1,12 +1,12 @@
 class UnspentOutputSelectorChain: IUnspentOutputSelector {
     var concreteSelectors = [IUnspentOutputSelector]()
 
-    func select(value: Int, feeRate: Int, outputScriptType: ScriptType, changeType: ScriptType, senderPay: Bool, dust: Int, pluginDataOutputSize: Int) throws -> SelectedUnspentOutputInfo {
+    func select(value: Int, feeRate: Int, outputScriptType: ScriptType, changeType: ScriptType, senderPay: Bool, pluginDataOutputSize: Int) throws -> SelectedUnspentOutputInfo {
         var lastError: Error = BitcoinCoreErrors.Unexpected.unkown
 
         for selector in concreteSelectors {
             do {
-                return try selector.select(value: value, feeRate: feeRate, outputScriptType: outputScriptType, changeType: changeType, senderPay: senderPay, dust: dust, pluginDataOutputSize: pluginDataOutputSize)
+                return try selector.select(value: value, feeRate: feeRate, outputScriptType: outputScriptType, changeType: changeType, senderPay: senderPay, pluginDataOutputSize: pluginDataOutputSize)
             } catch {
                 lastError = error
             }

--- a/BitcoinCore/Classes/Models/Output.swift
+++ b/BitcoinCore/Classes/Models/Output.swift
@@ -17,7 +17,11 @@ public enum ScriptType: Int, DatabaseValueConvertible {
     }
 
     var witness: Bool {
-        return self == .p2wpkh || self == .p2wpkhSh || self == .p2wsh
+        self == .p2wpkh || self == .p2wpkhSh || self == .p2wsh
+    }
+
+    var nativeSegwit: Bool {
+        self == .p2wpkh || self == .p2wsh
     }
 
 }

--- a/BitcoinCore/Classes/Transactions/Builder/DustCalculator.swift
+++ b/BitcoinCore/Classes/Transactions/Builder/DustCalculator.swift
@@ -1,10 +1,10 @@
-class DustCalculator {
+public class DustCalculator {
 
     private let minFeeRate: Int
     private let sizeCalculator: ITransactionSizeCalculator
 
-    init(dustRelayTxFee: Int, sizeCalculator: ITransactionSizeCalculator) {
-        // https://github.com/bitcoin/bitcoin/blob/94d6a18f23ec1add600f04fc7bd0808b7384d829/src/policy/feerate.cpp#L28
+    public init(dustRelayTxFee: Int, sizeCalculator: ITransactionSizeCalculator) {
+        // https://github.com/bitcoin/bitcoin/blob/master/src/policy/feerate.cpp#L26
         minFeeRate = dustRelayTxFee / 1000
 
         self.sizeCalculator = sizeCalculator
@@ -14,12 +14,12 @@ class DustCalculator {
 
 extension DustCalculator: IDustCalculator {
 
-    func dust(type: ScriptType) -> Int {
-        // https://github.com/bitcoin/bitcoin/blob/c536dfbcb00fb15963bf5d507b7017c241718bf6/src/policy/policy.cpp#L18
+    public func dust(type: ScriptType) -> Int {
+        // https://github.com/bitcoin/bitcoin/blob/master/src/policy/policy.cpp#L14
 
         var size = sizeCalculator.outputSize(type: type)
 
-        if type.witness {
+        if type.nativeSegwit {
             size += sizeCalculator.inputSize(type: .p2wpkh) + sizeCalculator.witnessSize(type: .p2wpkh) / 4
         } else {
             size += sizeCalculator.inputSize(type: .p2pkh)

--- a/BitcoinCore/Classes/Transactions/Builder/InputSetter.swift
+++ b/BitcoinCore/Classes/Transactions/Builder/InputSetter.swift
@@ -48,11 +48,10 @@ extension InputSetter: IInputSetter {
 
     func setInputs(to mutableTransaction: MutableTransaction, feeRate: Int, senderPay: Bool, sortType: TransactionDataSortType) throws {
         let value = mutableTransaction.recipientValue
-        let dust = dustCalculator.dust(type: changeScriptType)
         let unspentOutputInfo = try unspentOutputSelector.select(
                 value: value, feeRate: feeRate,
                 outputScriptType: mutableTransaction.recipientAddress.scriptType, changeType: changeScriptType,
-                senderPay: senderPay, dust: dust, pluginDataOutputSize: mutableTransaction.pluginDataOutputSize
+                senderPay: senderPay, pluginDataOutputSize: mutableTransaction.pluginDataOutputSize
         )
         let unspentOutputs = inputSorterFactory.sorter(for: sortType).sort(unspentOutputs: unspentOutputInfo.unspentOutputs)
 

--- a/BitcoinKit/Classes/Network/MainNet.swift
+++ b/BitcoinKit/Classes/Network/MainNet.swift
@@ -24,5 +24,5 @@ class MainNet: INetwork {
         "seed.bitcoin.jonasschnelli.ch",// Jonas Schnelli
     ]
 
-    let dustRelayTxFee = 3000 // https://github.com/bitcoin/bitcoin/blob/c536dfbcb00fb15963bf5d507b7017c241718bf6/src/policy/policy.h#L50
+    let dustRelayTxFee = 3000 //  https://github.com/bitcoin/bitcoin/blob/master/src/policy/policy.h#L52
 }

--- a/DashKit/Classes/Core/DashKit.swift
+++ b/DashKit/Classes/Core/DashKit.swift
@@ -125,8 +125,10 @@ public class DashKit: AbstractKit {
 
         let calculator = TransactionSizeCalculator()
         let confirmedUnspentOutputProvider = ConfirmedUnspentOutputProvider(storage: storage, confirmationsThreshold: confirmationsThreshold)
-        bitcoinCore.prepend(unspentOutputSelector: UnspentOutputSelector(calculator: calculator, provider: confirmedUnspentOutputProvider))
-        bitcoinCore.prepend(unspentOutputSelector: UnspentOutputSelectorSingleNoChange(calculator: calculator, provider: confirmedUnspentOutputProvider))
+        let dustCalculator = DustCalculator(dustRelayTxFee: network.dustRelayTxFee, sizeCalculator: calculator)
+
+        bitcoinCore.prepend(unspentOutputSelector: UnspentOutputSelector(calculator: calculator, provider: confirmedUnspentOutputProvider, dustCalculator: dustCalculator))
+        bitcoinCore.prepend(unspentOutputSelector: UnspentOutputSelectorSingleNoChange(calculator: calculator, provider: confirmedUnspentOutputProvider, dustCalculator: dustCalculator))
 // --------------------------------------
         let transactionLockVoteValidator = TransactionLockVoteValidator(storage: storage, hasher: singleHasher)
         let instantSendLockValidator = InstantSendLockValidator(quorumListManager: quorumListManager, hasher: doubleShaHasher)

--- a/DashKit/Classes/Network/MainNet.swift
+++ b/DashKit/Classes/Network/MainNet.swift
@@ -24,5 +24,5 @@ class MainNet: INetwork {
         "dnsseed.masternode.io",
     ]
 
-    let dustRelayTxFee = 1000 // https://github.com/dashpay/dash/blob/master/src/policy/policy.h#L36
+    let dustRelayTxFee = 3000 // https://github.com/dashpay/dash/blob/master/src/policy/policy.h#L38
 }

--- a/Example/Tests/BitcoinCore/Managers/UnspentOutputSelectorOldTests.swift
+++ b/Example/Tests/BitcoinCore/Managers/UnspentOutputSelectorOldTests.swift
@@ -11,19 +11,21 @@ class UnspentOutputSelectorOldTests: XCTestCase {
 
     var mockTransactionSizeCalculator: MockITransactionSizeCalculator!
     var mockUnspentOutputProvider: MockIUnspentOutputProvider!
+    var mockDustCalculator: MockIDustCalculator!
 
     override func setUp() {
         super.setUp()
 
         mockTransactionSizeCalculator = MockITransactionSizeCalculator()
         mockUnspentOutputProvider = MockIUnspentOutputProvider()
+        mockDustCalculator = MockIDustCalculator()
 
         stub(mockTransactionSizeCalculator) { mock in
             when(mock.inputSize(type: any())).thenReturn(10)
             when(mock.outputSize(type: any())).thenReturn(2)
             when(mock.transactionSize(previousOutputs: any(), outputScriptTypes: any(), pluginDataOutputSize: 0)).thenReturn(100)
         }
-        unspentOutputSelector = UnspentOutputSelector(calculator: mockTransactionSizeCalculator, provider: mockUnspentOutputProvider)
+        unspentOutputSelector = UnspentOutputSelector(calculator: mockTransactionSizeCalculator, provider: mockUnspentOutputProvider, dustCalculator: mockDustCalculator)
 
         outputs = [TestData.unspentOutput(output: Output(withValue: 1000, index: 0, lockingScript: Data(), type: .p2pkh, keyHash: Data())),
                    TestData.unspentOutput(output: Output(withValue: 2000, index: 0, lockingScript: Data(), type: .p2pkh, keyHash: Data())),
@@ -33,6 +35,9 @@ class UnspentOutputSelectorOldTests: XCTestCase {
         ]
         stub(mockUnspentOutputProvider) { mock in
             when(mock.spendableUtxo.get).thenReturn(outputs)
+        }
+        stub(mockDustCalculator) { mock in
+            when(mock.dust(type: any())).thenReturn(dust)
         }
     }
 
@@ -47,7 +52,7 @@ class UnspentOutputSelectorOldTests: XCTestCase {
 
     func testSummaryValueReceiverPay() {
         do {
-            let selectedOutputs = try unspentOutputSelector.select(value: 7000, feeRate: 1, senderPay: false, dust: dust, pluginDataOutputSize: 0)
+            let selectedOutputs = try unspentOutputSelector.select(value: 7000, feeRate: 1, senderPay: false, pluginDataOutputSize: 0)
             XCTAssertEqual(selectedOutputs.unspentOutputs, [outputs[0], outputs[1], outputs[2]])
             XCTAssertEqual(selectedOutputs.recipientValue, 7000 - 100)
             XCTAssertEqual(selectedOutputs.changeValue, nil)
@@ -59,7 +64,7 @@ class UnspentOutputSelectorOldTests: XCTestCase {
     func testSummaryValueSenderPay() {
         // with change output
         do {
-            let selectedOutputs = try unspentOutputSelector.select(value: 7000, feeRate: 1, senderPay: true, dust: dust, pluginDataOutputSize: 0)
+            let selectedOutputs = try unspentOutputSelector.select(value: 7000, feeRate: 1, senderPay: true, pluginDataOutputSize: 0)
             XCTAssertEqual(selectedOutputs.unspentOutputs, [outputs[0], outputs[1], outputs[2], outputs[3]])
             XCTAssertEqual(selectedOutputs.recipientValue, 7000)
             XCTAssertEqual(selectedOutputs.changeValue, 15000 - 7000 - 100)
@@ -67,9 +72,13 @@ class UnspentOutputSelectorOldTests: XCTestCase {
             XCTFail("Unexpected error!")
         }
         // without change output
+        stub(mockDustCalculator) { mock in
+            when(mock.dust(type: any())).thenReturn(dust + 1)
+        }
+
         do {
             let expectedFee = 100 + 10 + 2  // fee for tx + fee for change input + fee for change output
-            let selectedOutputs = try unspentOutputSelector.select(value: 15000 - expectedFee, feeRate: 1, senderPay: true, dust: dust + 1, pluginDataOutputSize: 0)
+            let selectedOutputs = try unspentOutputSelector.select(value: 15000 - expectedFee, feeRate: 1, senderPay: true, pluginDataOutputSize: 0)
             XCTAssertEqual(selectedOutputs.unspentOutputs, [outputs[0], outputs[1], outputs[2], outputs[3]])
             XCTAssertEqual(selectedOutputs.recipientValue, 15000 - expectedFee)
             XCTAssertEqual(selectedOutputs.changeValue, nil)
@@ -80,7 +89,7 @@ class UnspentOutputSelectorOldTests: XCTestCase {
 
     func testNotEnoughErrorReceiverPay() {
         do {
-            _ = try unspentOutputSelector.select(value: 31001, feeRate: 1, senderPay: false, dust: dust, pluginDataOutputSize: 0)
+            _ = try unspentOutputSelector.select(value: 31001, feeRate: 1, senderPay: false, pluginDataOutputSize: 0)
             XCTFail("Wrong value summary!")
         } catch let error as BitcoinCoreErrors.SendValueErrors {
             XCTAssertEqual(error, BitcoinCoreErrors.SendValueErrors.notEnough)
@@ -91,7 +100,7 @@ class UnspentOutputSelectorOldTests: XCTestCase {
 
     func testNotEnoughErrorSenderPay() {
         do {
-            _ = try unspentOutputSelector.select(value: 30901, feeRate: 1, senderPay: true, dust: dust, pluginDataOutputSize: 0)
+            _ = try unspentOutputSelector.select(value: 30901, feeRate: 1, senderPay: true, pluginDataOutputSize: 0)
             XCTFail("Wrong value summary!")
         } catch let error as BitcoinCoreErrors.SendValueErrors {
             XCTAssertEqual(error, BitcoinCoreErrors.SendValueErrors.notEnough)
@@ -105,7 +114,7 @@ class UnspentOutputSelectorOldTests: XCTestCase {
             when(mock.spendableUtxo.get).thenReturn([])
         }
         do {
-            _ = try unspentOutputSelector.select(value: 100, feeRate: 1, senderPay: false, dust: dust, pluginDataOutputSize: 0)
+            _ = try unspentOutputSelector.select(value: 100, feeRate: 1, senderPay: false, pluginDataOutputSize: 0)
             XCTFail("Wrong value summary!")
         } catch let error as BitcoinCoreErrors.SendValueErrors {
             XCTAssertEqual(error, BitcoinCoreErrors.SendValueErrors.emptyOutputs)

--- a/LitecoinKit/Classes/Network/MainNet.swift
+++ b/LitecoinKit/Classes/Network/MainNet.swift
@@ -23,5 +23,5 @@ class MainNet: INetwork {
         "dnsseed.litecointools.com",
     ]
 
-    let dustRelayTxFee = 3000 // https://github.com/bitcoin/bitcoin/blob/c536dfbcb00fb15963bf5d507b7017c241718bf6/src/policy/policy.h#L50
+    let dustRelayTxFee = 3000
 }


### PR DESCRIPTION
- UnspentOutputSelector and UnspentOutputSelectorSingleNoChange must calculate dust for "recipient" and "change" outputs separately
- DustCalculator must calculate dust for .p2wpkhSh as for nonSegwit transaction