### PR TITLE
Unwrap optional baseAddress of a unsafe bytes object in PeerConnection

### DIFF
--- a/BitcoinCore/Classes/Network/Peer/PeerAddressManagerState.swift
+++ b/BitcoinCore/Classes/Network/Peer/PeerAddressManagerState.swift
@@ -1,18 +1,13 @@
 import Foundation
 
 class PeerAddressManagerState {
-    private let queue = DispatchQueue(label: "io.horizontalsystems.bitcoin-core.peer-address-manager-state", qos: .utility)
     private(set) var usedIps: [String] = []
 
     func add(usedIp: String) {
-        queue.sync {
-            self.usedIps.append(usedIp)
-        }
+        usedIps.append(usedIp)
     }
 
     func remove(usedIp: String) {
-        queue.sync {
-            self.usedIps.removeAll(where: { $0 == usedIp })
-        }
+        usedIps.removeAll(where: { $0 == usedIp })
     }
 }

--- a/BitcoinCore/Classes/Network/Peer/PeerConnection.swift
+++ b/BitcoinCore/Classes/Network/Peer/PeerConnection.swift
@@ -165,8 +165,11 @@ extension PeerConnection: IPeerConnection {
             guard !data.isEmpty else {
                 return
             }
-            _ = data.withUnsafeBytes {
-                outputStream?.write($0.baseAddress!.assumingMemoryBound(to: UInt8.self), maxLength: data.count)
+            data.withUnsafeBytes {
+                guard let pointer = $0.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                    return
+                }
+                outputStream?.write(pointer, maxLength: data.count)
             }
         } catch {
             log("Connection can't send message \(message) with error \(error)", level: .error) //todo catch error when try send message not registered in serializers


### PR DESCRIPTION
- Wrap all PeerAddressManager calls to storage and state in a serial queue