### PR TITLE
Improve unspent output selection logic

### DIFF
--- a/BitcoinCore/Classes/Managers/UnspentOutputSelector.swift
+++ b/BitcoinCore/Classes/Managers/UnspentOutputSelector.swift
@@ -43,7 +43,11 @@ extension UnspentOutputSelector: IUnspentOutputSelector {
             throw BitcoinCoreErrors.SendValueErrors.emptyOutputs
         }
 
-        let sortedOutputs = unspentOutputs.sorted(by: { lhs, rhs in lhs.output.value < rhs.output.value })
+        let sortedOutputs = unspentOutputs.sorted(by: { lhs, rhs in
+            (lhs.output.failedToSpend && !rhs.output.failedToSpend) || (
+                    lhs.output.failedToSpend == rhs.output.failedToSpend &&  lhs.output.value < rhs.output.value
+            )
+        })
 
         // select unspentOutputs with least value until we get needed value
         var selectedOutputs = [UnspentOutput]()

--- a/BitcoinCore/Classes/Managers/UnspentOutputSelectorSingleNoChange.swift
+++ b/BitcoinCore/Classes/Managers/UnspentOutputSelectorSingleNoChange.swift
@@ -21,6 +21,9 @@ extension UnspentOutputSelectorSingleNoChange: IUnspentOutputSelector {
         let recipientOutputDust = dustCalculator.dust(type: outputScriptType)
         let changeOutputDust = dustCalculator.dust(type: changeType)
 
+        guard unspentOutputs.allSatisfy({ !$0.output.failedToSpend }) else {
+            throw BitcoinCoreErrors.SendValueErrors.singleNoChangeOutputNotFound
+        }
         guard value >= recipientOutputDust else {
             throw BitcoinCoreErrors.SendValueErrors.dust
         }

--- a/BitcoinCore/Classes/Models/Output.swift
+++ b/BitcoinCore/Classes/Models/Output.swift
@@ -38,6 +38,7 @@ public class Output: Record {
     public var redeemScript: Data? = nil
     public var keyHash: Data? = nil
     var address: String? = nil
+    var failedToSpend: Bool = false
 
     public var pluginId: UInt8? = nil
     public var pluginData: String? = nil
@@ -82,6 +83,7 @@ public class Output: Record {
         case address
         case pluginId
         case pluginData
+        case failedToSpend
     }
 
     required init(row: Row) {
@@ -97,6 +99,7 @@ public class Output: Record {
         address = row[Columns.address]
         pluginId = row[Columns.pluginId]
         pluginData = row[Columns.pluginData]
+        failedToSpend = row[Columns.failedToSpend]
 
         super.init(row: row)
     }
@@ -114,6 +117,7 @@ public class Output: Record {
         container[Columns.address] = address
         container[Columns.pluginId] = pluginId
         container[Columns.pluginData] = pluginData
+        container[Columns.failedToSpend] = failedToSpend
     }
 
 }

--- a/BitcoinCore/Classes/Network/TransactionSender.swift
+++ b/BitcoinCore/Classes/Network/TransactionSender.swift
@@ -32,7 +32,7 @@ class TransactionSender {
     }
 
     private func peersToSendTo() -> [IPeer] {
-        var syncedPeers = initialBlockDownload.syncedPeers
+        let syncedPeers = initialBlockDownload.syncedPeers
         guard let freeSyncedPeer = syncedPeers.sorted(by: { !$0.ready && $1.ready }).first else {
             return []
         }
@@ -41,7 +41,7 @@ class TransactionSender {
             return []
         }
 
-        var sortedPeers = peerManager.readyPeers
+        let sortedPeers = peerManager.readyPeers
                 .filter {
                     freeSyncedPeer !== $0
                 }
@@ -76,6 +76,7 @@ class TransactionSender {
         sentTransaction.sendSuccess = true
 
         if sentTransaction.retriesCount >= maxRetriesCount {
+            transactionSyncer.handleInvalid(fullTransaction: transaction)
             storage.delete(sentTransaction: sentTransaction)
         } else {
             storage.update(sentTransaction: sentTransaction)

--- a/Example/Tests/BitcoinCore/Managers/UnspentOutputSelectorSingleNoChangeTests.swift
+++ b/Example/Tests/BitcoinCore/Managers/UnspentOutputSelectorSingleNoChangeTests.swift
@@ -123,6 +123,22 @@ class UnspentOutputSelectorSingleNoChangeTests: QuickSpec {
                     fail("Unexpected error")
                 }
             }
+
+            it("doesn't select it if there's an output failed to spend before") {
+                defer {
+                    outputs.first?.output.failedToSpend = false
+                }
+
+                do {
+                    outputs.first?.output.failedToSpend = true
+                    _ = try selector.select(value: value, feeRate: feeRate, outputScriptType: .p2pkh, changeType: .p2pkh, senderPay: false, pluginDataOutputSize: 0)
+                    fail("Exception expected")
+                } catch let error as BitcoinCoreErrors.SendValueErrors {
+                    expect(error).to(equal(BitcoinCoreErrors.SendValueErrors.singleNoChangeOutputNotFound))
+                } catch {
+                    fail("Unexpected error")
+                }
+            }
         }
     }
 

--- a/Example/Tests/BitcoinCore/Managers/UnspentOutputSelectorTests.swift
+++ b/Example/Tests/BitcoinCore/Managers/UnspentOutputSelectorTests.swift
@@ -39,7 +39,7 @@ class UnspentOutputSelectorTests: QuickSpec {
 
         let outputs = [TestData.unspentOutput(output: Output(withValue: 1000, index: 0, lockingScript: Data(), type: .p2pkh, keyHash: Data())),
                        TestData.unspentOutput(output: Output(withValue: 2000, index: 0, lockingScript: Data(), type: .p2pkh, keyHash: Data())),
-                       TestData.unspentOutput(output: Output(withValue: 4000, index: 0, lockingScript: Data(), type: .p2pkh, keyHash: Data())),
+                       TestData.unspentOutput(output: Output(withValue: 3000, index: 0, lockingScript: Data(), type: .p2pkh, keyHash: Data())),
                        TestData.unspentOutput(output: Output(withValue: 8000, index: 0, lockingScript: Data(), type: .p2pkh, keyHash: Data())),
                        TestData.unspentOutput(output: Output(withValue: 16000, index: 0, lockingScript: Data(), type: .p2pkh, keyHash: Data()))
         ]
@@ -128,6 +128,22 @@ class UnspentOutputSelectorTests: QuickSpec {
                     } catch {
                         fail("Unexpected error")
                     }
+                }
+            }
+
+            context("when there is an output failed to spend before") {
+                beforeEach {
+                    outputs[2].output.failedToSpend = true
+                }
+                afterEach {
+                    outputs[2].output.failedToSpend = false
+                }
+
+                it("selects output failed to spend") {
+                    let selectedOutputs = try! selector.select(value: totalValue - fee, feeRate: feeRate, outputScriptType: .p2pkh, changeType: .p2pkh, senderPay: true, pluginDataOutputSize: 0)
+                    expect(selectedOutputs.unspentOutputs).to(equal([outputs[2]]))
+                    expect(selectedOutputs.recipientValue).to(equal(totalValue - fee))
+                    expect(selectedOutputs.changeValue).to(beNil())
                 }
             }
         }


### PR DESCRIPTION
- Firstly, select outputs formerly failed to spend. This is to avoid a following case:
   1. A transaction TX1 is failed to be spent. (We fail to get confirmation that it's in mempool)
   2. It's actually added to mempool.
   3. A user tries to send the same amount for the second time (TX2). If TX2 doesn't use outputs spent by TX1, it may be successfully sent, thus, having both TX1 and TX2 being sent.
- Invalidate transaction if cannot be broadcasted for 3 times